### PR TITLE
build(Emscripten): Use EMSCRIPTEN_KEEPALIVE over EXPORTED_FUNCTIONS

### DIFF
--- a/include/itkWASMExports.h
+++ b/include/itkWASMExports.h
@@ -23,6 +23,12 @@
 
 #include "itkWASMDataObject.h"
 
+#if defined(__EMSCRIPTEN__)
+#  include "emscripten/em_macros.h"
+#else
+#  define EMSCRIPTEN_KEEPALIVE
+#endif
+
 namespace itk
 {
 namespace wasm
@@ -43,15 +49,15 @@ void setMemoryStoreOutputArray(uint32_t memoryIndex, uint32_t index, uint32_t su
 extern "C"
 {
 
-size_t itk_wasm_input_array_alloc(uint32_t memoryIndex, uint32_t index, uint32_t subIndex, size_t size);
-size_t itk_wasm_input_json_alloc(uint32_t memoryIndex, uint32_t index, size_t size);
+size_t EMSCRIPTEN_KEEPALIVE itk_wasm_input_array_alloc(uint32_t memoryIndex, uint32_t index, uint32_t subIndex, size_t size);
+size_t EMSCRIPTEN_KEEPALIVE itk_wasm_input_json_alloc(uint32_t memoryIndex, uint32_t index, size_t size);
 
-size_t itk_wasm_output_json_address(uint32_t memoryIndex, uint32_t index);
-size_t itk_wasm_output_json_size(uint32_t memoryIndex, uint32_t index);
-size_t itk_wasm_output_array_address(uint32_t memoryIndex, uint32_t index, uint32_t subIndex);
-size_t itk_wasm_output_array_size(uint32_t memoryIndex, uint32_t index, uint32_t subIndex);
+size_t EMSCRIPTEN_KEEPALIVE itk_wasm_output_json_address(uint32_t memoryIndex, uint32_t index);
+size_t EMSCRIPTEN_KEEPALIVE itk_wasm_output_json_size(uint32_t memoryIndex, uint32_t index);
+size_t EMSCRIPTEN_KEEPALIVE itk_wasm_output_array_address(uint32_t memoryIndex, uint32_t index, uint32_t subIndex);
+size_t EMSCRIPTEN_KEEPALIVE itk_wasm_output_array_size(uint32_t memoryIndex, uint32_t index, uint32_t subIndex);
 
-void itk_wasm_free_all();
+void EMSCRIPTEN_KEEPALIVE itk_wasm_free_all();
 
 } // end extern "C"
 

--- a/src/docker/itk-wasm/ITKWebAssemblyInterface.cmake
+++ b/src/docker/itk-wasm/ITKWebAssemblyInterface.cmake
@@ -35,7 +35,7 @@ function(add_executable target)
     _add_executable(${umd_target} ${ARGN})
 
     get_property(_link_flags TARGET ${target} PROPERTY LINK_FLAGS)
-    set(common_link_flags " -s FORCE_FILESYSTEM=1 -s EXPORTED_RUNTIME_METHODS='[\"callMain\",\"cwrap\",\"ccall\",\"writeArrayToMemory\",\"writeAsciiToMemory\",\"AsciiToString\"]'  -flto -s WASM=1 -lnodefs.js -s WASM_ASYNC_COMPILATION=1 -s EXPORT_NAME=${target} -s MODULARIZE=1 -s EXIT_RUNTIME=0 -s INVOKE_RUN=0 --pre-js /ITKWebAssemblyInterface/src/emscripten-module/itkJSPipelinePre.js --post-js /ITKWebAssemblyInterface/src/emscripten-module/itkJSPost.js -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s EXPORTED_FUNCTIONS='[\"_main\",\"_itk_wasm_input_array_alloc\",\"_itk_wasm_input_json_alloc\",\"_itk_wasm_output_json_address\",\"_itk_wasm_output_json_size\",\"_itk_wasm_output_array_address\",\"_itk_wasm_output_array_size\",\"_itk_wasm_free_all\"]' ${_link_flags}")
+    set(common_link_flags " -s FORCE_FILESYSTEM=1 -s EXPORTED_RUNTIME_METHODS='[\"callMain\",\"cwrap\",\"ccall\",\"writeArrayToMemory\",\"writeAsciiToMemory\",\"AsciiToString\"]'  -flto -s WASM=1 -lnodefs.js -s WASM_ASYNC_COMPILATION=1 -s EXPORT_NAME=${target} -s MODULARIZE=1 -s EXIT_RUNTIME=0 -s INVOKE_RUN=0 --pre-js /ITKWebAssemblyInterface/src/emscripten-module/itkJSPipelinePre.js --post-js /ITKWebAssemblyInterface/src/emscripten-module/itkJSPost.js -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s EXPORTED_FUNCTIONS='[\"_main\"]' ${_link_flags}")
     set_property(TARGET ${wasm_target} PROPERTY LINK_FLAGS "${common_link_flags} -s EXPORT_ES6=1 -s USE_ES6_IMPORT_META=0")
     set_property(TARGET ${umd_target} PROPERTY LINK_FLAGS "${common_link_flags}")
 


### PR DESCRIPTION
Avoid missing symbols when an executable does not link to the
WebAssemblyInterface library.
