### PR TITLE
fix(readDICOMTags): import InterfaceTypes directly

### DIFF
--- a/src/io/readDICOMTags.ts
+++ b/src/io/readDICOMTags.ts
@@ -6,7 +6,7 @@ import TextStream from '../core/TextStream.js'
 import config from '../itkConfig.js'
 
 import ReadDICOMTagsResult from './ReadDICOMTagsResult.js'
-import { InterfaceTypes } from '../index.js'
+import InterfaceTypes from '../core/InterfaceTypes.js'
 
 async function readDICOMTags (webWorker: Worker, file: File, tags: string[] | null = null): Promise<ReadDICOMTagsResult> {
   let worker = webWorker


### PR DESCRIPTION
Importing from '../index.js' pulls in node imports, which is not
desirable for web-based distribution. Instead of importing from index, import directly from InterfaceTypes.

Fixes #470.