### PR TITLE
fix(itk-wasm-cli.js): Use path.join to construct dockcrossScript

### DIFF
--- a/src/itk-wasm-cli.js
+++ b/src/itk-wasm-cli.js
@@ -60,7 +60,7 @@ function processCommonOptions() {
   }
 
   // Ensure we have the 'dockcross' Docker build environment driver script
-  const dockcrossScript = `${buildDir}/itk-wasm-build-env`
+  const dockcrossScript = path.join(buildDir, 'itk-wasm-build-env')
   try {
     fs.statSync(dockcrossScript)
   } catch (err) {


### PR DESCRIPTION
Otherwise we can end up with `//` in the path, which causes issues down
the line.
