### PR TITLE
build(io-packages): Remove dependency on itk-wasm

### DIFF
--- a/src/io/internal/bindings/image-io.package.json.in
+++ b/src/io/internal/bindings/image-io.package.json.in
@@ -29,6 +29,5 @@
   "devDependencies": {
   },
   "dependencies": {
-    "itk-wasm": "sem-ver"
   }
 }

--- a/src/io/internal/bindings/mesh-io.package.json.in
+++ b/src/io/internal/bindings/mesh-io.package.json.in
@@ -29,6 +29,5 @@
   "devDependencies": {
   },
   "dependencies": {
-    "itk-wasm": "sem-ver"
   }
 }


### PR DESCRIPTION
These are optional dependencies for itk-wasm. Avoid pulling down
node_modules/itk-image-io/node_modules/itk-wasm/*