### PR TITLE
refactor(writeImage,Mesh): useCompression argument comes last

### DIFF
--- a/doc/content/docs/itk_js_to_itk_wasm_migration_guide.md
+++ b/doc/content/docs/itk_js_to_itk_wasm_migration_guide.md
@@ -127,3 +127,7 @@ The VTK Docker images, VTK PolyData IO, `readPolyDataFile`, `readPolyDataBlob`, 
 ## IOTypes
 
 The use of `IOTypes` in pipelines is deprecated and not expected to work in the future. These have been replaced by `InterfaceTypes`.
+
+## Argument order when writing image, mesh binaries
+
+The `useCompression` argument is now last in `writeArrayBuffer`, `writeImageArrayBuffer`, `writeImageLocalFile`, `writeMeshArrayBuffer`, `writeMeshLocalFile`.

--- a/src/io/writeArrayBuffer.ts
+++ b/src/io/writeArrayBuffer.ts
@@ -10,19 +10,23 @@ import Mesh from '../core/Mesh.js'
 
 import WriteArrayBufferResult from './WriteArrayBufferResult.js'
 
-async function writeArrayBuffer (webWorker: Worker | null, useCompression: boolean, imageOrMesh: Image | Mesh, fileName: string, mimeType: string): Promise<WriteArrayBufferResult> {
+async function writeArrayBuffer (webWorker: Worker | null, imageOrMesh: Image | Mesh, fileName: string, mimeType: string = '', useCompression: boolean = false): Promise<WriteArrayBufferResult> {
+  if (typeof imageOrMesh === 'boolean') {
+    throw new Error('useCompression is now the argument position in itk-wasm')
+  }
+
   const extension = getFileExtension(fileName)
   const isMesh = !!extensionToMeshIO.has(extension) || !!mimeToMeshIO.has(mimeType)
   if (isMesh) {
-    return await writeMeshArrayBuffer(webWorker, { useCompression }, imageOrMesh as Mesh, fileName, mimeType)
+    return await writeMeshArrayBuffer(webWorker, imageOrMesh as Mesh, fileName, mimeType, { useCompression })
       .catch(async function () {
         if (webWorker != null) {
           webWorker.terminate()
         }
-        return await writeImageArrayBuffer(null, useCompression, imageOrMesh as Image, fileName, mimeType)
+        return await writeImageArrayBuffer(null, imageOrMesh as Image, fileName, mimeType, useCompression)
       })
   } else {
-    return await writeImageArrayBuffer(webWorker, useCompression, imageOrMesh as Image, fileName, mimeType)
+    return await writeImageArrayBuffer(webWorker, imageOrMesh as Image, fileName, mimeType, useCompression)
   }
 }
 

--- a/src/io/writeImageArrayBuffer.ts
+++ b/src/io/writeImageArrayBuffer.ts
@@ -10,7 +10,11 @@ import getTransferable from '../core/getTransferable.js'
 
 import WriteArrayBufferResult from './WriteArrayBufferResult.js'
 
-async function writeImageArrayBuffer (webWorker: Worker | null, useCompression: boolean, image: Image, fileName: string, mimeType: string): Promise<WriteArrayBufferResult> {
+async function writeImageArrayBuffer (webWorker: Worker | null, image: Image, fileName: string, mimeType: string = '', useCompression: boolean = false): Promise<WriteArrayBufferResult> {
+  if (typeof image === 'boolean') {
+    throw new Error('useCompression is now at the last argument position in itk-wasm')
+  }
+
   let worker = webWorker
   const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise('pipeline', worker)
   worker = usedWorker

--- a/src/io/writeImageLocalFile.ts
+++ b/src/io/writeImageLocalFile.ts
@@ -19,13 +19,17 @@ import Image from '../core/Image.js'
 /**
  * Write an image to a file on the local filesystem in Node.js.
  *
- * @param: useCompression compression the pixel data when possible
  * @param: image itk.Image instance to write
  * @param: filePath path to the file on the local filesystem.
+ * @param: useCompression compression the pixel data when possible
  *
  * @return Promise<null>
  */
-async function writeImageLocalFile (useCompression: boolean, image: Image, filePath: string): Promise<null> {
+async function writeImageLocalFile (image: Image, filePath: string, useCompression: boolean = false): Promise<null> {
+  if (typeof image === 'boolean') {
+    throw new Error('useCompression is now the last argument in itk-wasm')
+  }
+
   const imageIOsPath = findLocalImageIOPath()
   const absoluteFilePath = path.resolve(filePath)
   const mimeType = mime.lookup(absoluteFilePath)

--- a/src/io/writeLocalFile.ts
+++ b/src/io/writeLocalFile.ts
@@ -12,28 +12,28 @@ import Image from '../core/Image.js'
 /**
  * Write an image or mesh to a file on the local filesystem in Node.js.
  *
- * @param: useCompression compression the pixel data when possible
  * @param: imageOrMesh itk.Image or itk.Mesh instance to write
  * @param: filePath path to the file on the local filesystem.
+ * @param: useCompression compression the pixel data when possible
  *
  * @return empty Promise
  */
-async function writeLocalFile (useCompression: boolean, imageOrMesh: Image | Mesh, filePath: string): Promise<null> {
+async function writeLocalFile (imageOrMesh: Image | Mesh, filePath: string, useCompression: boolean = false): Promise<null> {
   const absoluteFilePath = path.resolve(filePath)
   const extension = getFileExtension(absoluteFilePath)
 
   const isMesh = extensionToMeshIO.has(extension)
   if (isMesh) {
     try {
-      await writeMeshLocalFile({ useCompression }, imageOrMesh as Mesh, filePath)
+      await writeMeshLocalFile(imageOrMesh as Mesh, filePath, { useCompression })
       return null
     } catch (err) {
       // Was a .vtk image file? Continue to write as an image.
-      await writeImageLocalFile(useCompression, imageOrMesh as Image, filePath)
+      await writeImageLocalFile(imageOrMesh as Image, filePath, useCompression)
       return null
     }
   } else {
-    await writeImageLocalFile(useCompression, imageOrMesh as Image, filePath)
+    await writeImageLocalFile(imageOrMesh as Image, filePath, useCompression)
     return null
   }
 }

--- a/src/io/writeMeshArrayBuffer.ts
+++ b/src/io/writeMeshArrayBuffer.ts
@@ -9,17 +9,21 @@ import PipelineInput from '../pipeline/PipelineInput.js'
 import PipelineOutput from '../pipeline/PipelineOutput.js'
 import InterfaceTypes from '../core/InterfaceTypes.js'
 
-async function writeMeshArrayBuffer (webWorker: Worker | null, options: WriteMeshOptions, mesh: Mesh, fileName: string, mimeType: string): Promise<WriteArrayBufferResult> {
+async function writeMeshArrayBuffer (webWorker: Worker | null, mesh: Mesh, fileName: string, mimeType: string, options: WriteMeshOptions): Promise<WriteArrayBufferResult> {
+  if ('useCompression' in (mesh as any) || 'binaryFileType' in (mesh as any)) {
+    throw new Error('options are now in the last argument position in itk-wasm')
+  }
+
   let worker = webWorker
   const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise('pipeline', worker)
   worker = usedWorker
 
   const filePath = `./${fileName}`
   const args = ['0', filePath, '--memory-io', '--quiet']
-  if (options.useCompression === true) {
+  if (options?.useCompression === true) {
     args.push('--use-compression')
   }
-  if (options.binaryFileType === true) {
+  if (options?.binaryFileType === true) {
     args.push('--binary-file-type')
   }
   const outputs = [

--- a/src/io/writeMeshLocalFile.ts
+++ b/src/io/writeMeshLocalFile.ts
@@ -19,25 +19,29 @@ import Mesh from '../core/Mesh.js'
 /**
  * Write a mesh to a file on the local filesystem in Node.js.
  *
- * @param: useCompression compression the pixel data when possible
- * @param: binaryFileType write in an binary as opposed to a ascii format, if
- * possible
  * @param: mesh itk.Mesh instance to write
  * @param: filePath path to the file on the local filesystem.
+ * @param: options.useCompression compression the pixel data when possible
+ * @param: options.binaryFileType write in an binary as opposed to a ascii format, if
+ * possible
  *
  * @return empty Promise
  */
-async function writeMeshLocalFile (options: WriteMeshOptions, mesh: Mesh, filePath: string): Promise<null> {
+async function writeMeshLocalFile (mesh: Mesh, filePath: string, options: WriteMeshOptions): Promise<null> {
+  if ('useCompression' in (mesh as any) || 'binaryFileType' in (mesh as any)) {
+    throw new Error('options are now in the last argument position in itk-wasm')
+  }
+
   const meshIOsPath = findLocalMeshIOPath()
   const absoluteFilePath = path.resolve(filePath)
   const mimeType = mime.lookup(absoluteFilePath)
   const extension = getFileExtension(absoluteFilePath)
 
   const args = ['0', absoluteFilePath, '--memory-io', '--quiet']
-  if (options.useCompression === true) {
+  if (options?.useCompression === true) {
     args.push('--use-compression')
   }
-  if (options.binaryFileType === true) {
+  if (options?.binaryFileType === true) {
     args.push('--binary-file-type')
   }
   const desiredOutputs = [

--- a/test/browser/io/writeImageTest.js
+++ b/test/browser/io/writeImageTest.js
@@ -40,7 +40,7 @@ export default function () {
         return readImageArrayBuffer(null, arrayBuffer, 'cthead1Small.png').then(function ({ image, webWorker }) {
           webWorker.terminate()
           const useCompression = false
-          return writeImageArrayBuffer(null, useCompression, image, 'cthead1Small.png')
+          return writeImageArrayBuffer(null, image, 'cthead1Small.png', useCompression)
         })
       })
       .then(function ({ arrayBuffer: writtenArrayBuffer, webWorker }) {

--- a/test/browser/io/writeMeshTest.js
+++ b/test/browser/io/writeMeshTest.js
@@ -24,7 +24,7 @@ export default function () {
         return readMeshArrayBuffer(null, response.data, 'cow.vtk').then(function ({ mesh, webWorker }) {
           webWorker.terminate()
           const useCompression = false
-          return writeMeshArrayBuffer(null, useCompression, mesh, 'cow.vtk')
+          return writeMeshArrayBuffer(null, mesh, 'cow.vtk', { useCompression })
         })
       })
       .then(function ({ arrayBuffer: writtenArrayBuffer, webWorker }) {

--- a/test/node/io/image/BYUTest.js
+++ b/test/node/io/image/BYUTest.js
@@ -25,7 +25,7 @@ test('readMeshLocalFile reads a BYU file path given on the local filesystem', t 
 test('writeMeshLocalFile writes a BYU file path on the local filesystem', (t) => {
   return readMeshLocalFile(testInputFilePath)
     .then(function (mesh) {
-      return writeMeshLocalFile({ useCompression: false, binaryFileType: false }, mesh, testOutputFilePath)
+      return writeMeshLocalFile(mesh, testOutputFilePath)
     })
     .then(function () {
       return readMeshLocalFile(testOutputFilePath).then(function (mesh) {

--- a/test/node/io/image/BioRadTest.js
+++ b/test/node/io/image/BioRadTest.js
@@ -34,7 +34,7 @@ test('Test reading a BioRad file', t => {
 test('Test writing a BioRad file', t => {
   return readImageLocalFile(testInputFilePath).then(function (image) {
     const useCompression = false
-    return writeImageLocalFile(useCompression, image, testOutputFilePath)
+    return writeImageLocalFile(image, testOutputFilePath, useCompression)
   })
     .then(function () {
       return readImageLocalFile(testOutputFilePath).then(function (image) {

--- a/test/node/io/image/MGHTest.js
+++ b/test/node/io/image/MGHTest.js
@@ -42,7 +42,7 @@ test('Test reading a MGH file', t => {
 test('Test writing a MGH file', t => {
   return readImageLocalFile(testInputFilePath).then(function (image) {
     const useCompression = false
-    return writeImageLocalFile(useCompression, image, testOutputFilePath)
+    return writeImageLocalFile(image, testOutputFilePath, useCompression)
   })
     .then(function () {
       return readImageLocalFile(testOutputFilePath).then(function (image) {

--- a/test/node/io/image/MetaImageTest.js
+++ b/test/node/io/image/MetaImageTest.js
@@ -46,8 +46,7 @@ test('Test reading a MetaImage file', t => {
 
 test('Test writing a MetaImage file', t => {
   return readImageLocalFile(testInputFilePath).then(function (image) {
-    const useCompression = false
-    return writeImageLocalFile(useCompression, image, testOutputFilePath)
+    return writeImageLocalFile(image, testOutputFilePath)
   })
     .then(function () {
       return readImageLocalFile(testOutputFilePath).then(function (image) {
@@ -88,8 +87,7 @@ test('Test reading a small MetaImage file', async t => {
 test('Test writing a small MetaImage file', async t => {
   let image = await readImageLocalFile(testSmallInputFilePath)
   verifySmallImage(t, image)
-  const useCompression = false
-  await writeImageLocalFile(useCompression, image, testSmallOutputFilePath)
+  await writeImageLocalFile(image, testSmallOutputFilePath)
   image = await readImageLocalFile(testSmallOutputFilePath)
   verifySmallImage(t, image)
 })

--- a/test/node/io/image/NRRDTest.js
+++ b/test/node/io/image/NRRDTest.js
@@ -41,8 +41,7 @@ test('Test reading a NRRD file', t => {
 
 test('Test writing a NRRD file', t => {
   return readImageLocalFile(testInputFilePath).then(function (image) {
-    const useCompression = false
-    return writeImageLocalFile(useCompression, image, testOutputFilePath)
+    return writeImageLocalFile(image, testOutputFilePath)
   })
     .then(function () {
       return readImageLocalFile(testOutputFilePath).then(function (image) {

--- a/test/node/io/image/NiftiTest.js
+++ b/test/node/io/image/NiftiTest.js
@@ -28,8 +28,7 @@ test('Test reading a Nifti file', t => {
 
 test('Test writing a Nifti file', t => {
   return readImageLocalFile(testInputFilePath).then(function (image) {
-    const useCompression = false
-    return writeImageLocalFile(useCompression, image, testOutputFilePath)
+    return writeImageLocalFile(image, testOutputFilePath)
   })
     .then(function () {
       return readImageLocalFile(testOutputFilePath).then(function (image) {

--- a/test/node/io/image/PNGTest.js
+++ b/test/node/io/image/PNGTest.js
@@ -33,7 +33,7 @@ test('Test reading a PNG file', t => {
 test('Test writing a PNG file', t => {
   return readImageLocalFile(testInputFilePath).then(function (image) {
     const useCompression = false
-    return writeImageLocalFile(useCompression, image, testOutputFilePath)
+    return writeImageLocalFile(image, testOutputFilePath, useCompression)
   })
     .then(function () {
       return readImageLocalFile(testOutputFilePath).then(function (image) {

--- a/test/node/io/image/TIFFTest.js
+++ b/test/node/io/image/TIFFTest.js
@@ -34,7 +34,7 @@ test('Test reading a TIFF file', t => {
 test('Test writing a TIFF file', t => {
   return readImageLocalFile(testInputFilePath).then(function (image) {
     const useCompression = false
-    return writeImageLocalFile(useCompression, image, testOutputFilePath)
+    return writeImageLocalFile(image, testOutputFilePath, useCompression)
   })
     .then(function () {
       return readImageLocalFile(testOutputFilePath).then(function (image) {

--- a/test/node/io/image/VTKTest.js
+++ b/test/node/io/image/VTKTest.js
@@ -42,7 +42,7 @@ test('Test reading a VTK legacy file', t => {
 test('Test writing a BioRad file', t => {
   return readImageLocalFile(testInputFilePath).then(function (image) {
     const useCompression = false
-    return writeImageLocalFile(useCompression, image, testOutputFilePath)
+    return writeImageLocalFile(image, testOutputFilePath, useCompression)
   })
     .then(function () {
       return readImageLocalFile(testOutputFilePath).then(function (image) {

--- a/test/node/io/image/WASMTest.js
+++ b/test/node/io/image/WASMTest.js
@@ -27,16 +27,14 @@ const verifyImage = (t, image) => {
 
 test('Test writing and reading an ITK WASM file', async (t) => {
   const image = await readImageLocalFile(testInputFilePath)
-  const useCompression = false
-  await writeImageLocalFile(useCompression, image, testOutputFilePath)
+  await writeImageLocalFile(image, testOutputFilePath)
   const resultImage = await readImageLocalFile(testOutputFilePath)
   verifyImage(t, resultImage)
 })
 
 test('Test writing and reading a ZSTD compressed ITK WASM file', async (t) => {
   const image = await readImageLocalFile(testInputFilePath)
-  const useCompression = false
-  await writeImageLocalFile(useCompression, image, testZstdOutputFilePath)
+  await writeImageLocalFile(image, testZstdOutputFilePath)
   const resultImage = await readImageLocalFile(testOutputFilePath)
   verifyImage(t, resultImage)
 })

--- a/test/node/io/image/writeImageLocalFileTest.js
+++ b/test/node/io/image/writeImageLocalFileTest.js
@@ -27,8 +27,7 @@ const verifyImage = (t, image) => {
 test('writeImageLocalFile writes a file path on the local filesystem', t => {
   return readImageLocalFile(testInputFilePath)
     .then(function (image) {
-      const useCompression = false
-      return writeImageLocalFile(useCompression, image, testOutputFilePath)
+      return writeImageLocalFile(image, testOutputFilePath)
     })
     .then(function () {
       return readImageLocalFile(testOutputFilePath).then(function (image) {

--- a/test/node/io/mesh/FreeSurferTest.js
+++ b/test/node/io/mesh/FreeSurferTest.js
@@ -27,7 +27,7 @@ test('readMeshLocalFile reads a FreeSurfer Ascii file path given on the local fi
 test('writeMeshLocalFile writes a FreeSurfer Ascii file path on the local filesystem', (t) => {
   return readMeshLocalFile(testAsciiInputFilePath)
     .then(function (mesh) {
-      return writeMeshLocalFile({ useCompression: false, binaryFileType: false }, mesh, testAsciiOutputFilePath)
+      return writeMeshLocalFile(mesh, testAsciiOutputFilePath)
     })
     .then(function () {
       return readMeshLocalFile(testAsciiOutputFilePath).then(function (mesh) {
@@ -45,7 +45,7 @@ test('readMeshLocalFile reads a FreeSurfer Binary file path given on the local f
 test('writeMeshLocalFile writes a FreeSurfer Binary file path on the local filesystem', (t) => {
   return readMeshLocalFile(testBinaryInputFilePath)
     .then(function (mesh) {
-      return writeMeshLocalFile({ useCompression: false, binaryFileType: true }, mesh, testBinaryOutputFilePath)
+      return writeMeshLocalFile(mesh, testBinaryOutputFilePath)
     })
     .then(function () {
       return readMeshLocalFile(testBinaryOutputFilePath).then(function (mesh) {

--- a/test/node/io/mesh/GIPLTest.js
+++ b/test/node/io/mesh/GIPLTest.js
@@ -41,8 +41,7 @@ test('Test reading a GIPL file', t => {
 
 test('Test writing a GIPL file', t => {
   return readImageLocalFile(testInputFilePath).then(function (image) {
-    const useCompression = false
-    return writeImageLocalFile(useCompression, image, testOutputFilePath)
+    return writeImageLocalFile(image, testOutputFilePath)
   })
     .then(function () {
       return readImageLocalFile(testOutputFilePath).then(function (image) {

--- a/test/node/io/mesh/OBJTest.js
+++ b/test/node/io/mesh/OBJTest.js
@@ -25,7 +25,7 @@ test('readMeshLocalFile reads a OBJ file path given on the local filesystem', t 
 test('writeMeshLocalFile writes a OBJ file path on the local filesystem', (t) => {
   return readMeshLocalFile(testInputFilePath)
     .then(function (mesh) {
-      return writeMeshLocalFile({ useCompression: false, binaryFileType: false }, mesh, testOutputFilePath)
+      return writeMeshLocalFile(mesh, testOutputFilePath)
     })
     .then(function () {
       return readMeshLocalFile(testOutputFilePath).then(function (mesh) {

--- a/test/node/io/mesh/OFFTest.js
+++ b/test/node/io/mesh/OFFTest.js
@@ -25,7 +25,7 @@ test('readMeshLocalFile reads a OFF file path given on the local filesystem', t 
 test('writeMeshLocalFile writes a OFF file path on the local filesystem', (t) => {
   return readMeshLocalFile(testInputFilePath)
     .then(function (mesh) {
-      return writeMeshLocalFile({ useCompression: false, binaryFileType: false }, mesh, testOutputFilePath)
+      return writeMeshLocalFile(mesh, testOutputFilePath)
     })
     .then(function () {
       return readMeshLocalFile(testOutputFilePath).then(function (mesh) {

--- a/test/node/io/mesh/STLTest.js
+++ b/test/node/io/mesh/STLTest.js
@@ -25,7 +25,7 @@ test('readMeshLocalFile reads a STL file path given on the local filesystem', t 
 test('writeMeshLocalFile writes a STL file path on the local filesystem', (t) => {
   return readMeshLocalFile(testInputFilePath)
     .then(function (mesh) {
-      return writeMeshLocalFile({ useCompression: false, binaryFileType: false }, mesh, testOutputFilePath)
+      return writeMeshLocalFile(mesh, testOutputFilePath)
     })
     .then(function () {
       return readMeshLocalFile(testOutputFilePath).then(function (mesh) {

--- a/test/node/io/mesh/writeMeshLocalFileTest.js
+++ b/test/node/io/mesh/writeMeshLocalFileTest.js
@@ -19,7 +19,7 @@ const verifyMesh = (t, mesh) => {
 test('writeMeshLocalFile writes a file path on the local filesystem', (t) => {
   return readMeshLocalFile(testInputFilePath)
     .then(function (mesh) {
-      return writeMeshLocalFile({ useCompression: false, binaryFileType: false }, mesh, testOutputFilePath)
+      return writeMeshLocalFile(mesh, testOutputFilePath, { useCompression: false, binaryFileType: false })
     })
     .then(function () {
       return readMeshLocalFile(testOutputFilePath).then(function (mesh) {


### PR DESCRIPTION
BREAKING_CHANGE: The `useCompression` argument now comes last in the functions that write images and meshes to array buffers and files