### PR TITLE
fix(jsDelivr): Remove *.umd.wasm files from package

### DIFF
--- a/examples/UMD/cypress/integration/load_data_spec.js
+++ b/examples/UMD/cypress/integration/load_data_spec.js
@@ -7,4 +7,3 @@ describe('Load data', () => {
     })
   })
 })
-

--- a/src/build-emscripten.js
+++ b/src/build-emscripten.js
@@ -135,6 +135,7 @@ if (options.copyBuildArtifacts) {
   }
   let imageIOFiles = glob.sync(path.join(buildDir, 'image-io', '*.js'))
   imageIOFiles = imageIOFiles.concat(glob.sync(path.join(buildDir, 'image-io', '*.wasm')))
+  imageIOFiles = imageIOFiles.filter((fn) => !fn.endsWith('.umd.wasm'))
   const copyImageIOModules = function (imageIOFile, callback) {
     const io = path.basename(imageIOFile)
     const output = path.join('dist', 'image-io', io)
@@ -148,6 +149,7 @@ if (options.copyBuildArtifacts) {
   }
   let meshIOFiles = glob.sync(path.join(buildDir, 'mesh-io', '*.js'))
   meshIOFiles = meshIOFiles.concat(glob.sync(path.join(buildDir, 'mesh-io', '*.wasm')))
+  meshIOFiles = meshIOFiles.filter((fn) => !fn.endsWith('.umd.wasm'))
   const copyMeshIOModules = function (meshIOFile, callback) {
     const io = path.basename(meshIOFile)
     const output = path.join('dist', 'mesh-io', io)

--- a/src/core/internal/loadEmscriptenModuleWebWorker.ts
+++ b/src/core/internal/loadEmscriptenModuleWebWorker.ts
@@ -24,7 +24,7 @@ async function loadEmscriptenModuleWebWorker(moduleRelativePathOrURL: string | U
   // importScripts / UMD is required over dynamic ESM import until Firefox
   // adds worker dynamic import support:
   // https://bugzilla.mozilla.org/show_bug.cgi?id=1540913
-  const wasmBinaryPath = `${modulePrefix}.umd.wasm`
+  const wasmBinaryPath = `${modulePrefix}.wasm`
   const response = await axios.get(wasmBinaryPath, { responseType: 'arraybuffer' })
   const wasmBinary = response.data
   const modulePath = `${modulePrefix}.umd.js`

--- a/src/io/internal/pipelines/image/ReadDICOM/CMakeLists.txt
+++ b/src/io/internal/pipelines/image/ReadDICOM/CMakeLists.txt
@@ -90,7 +90,7 @@ if (EMSCRIPTEN AND DEFINED WebAssemblyInterface_BINARY_DIR)
         PROPERTY RUNTIME_OUTPUT_DIRECTORY
         ${WebAssemblyInterface_BINARY_DIR}/image-io
         )
-      set_property(TARGET ${target_umd} APPEND_STRING
+      set_property(TARGET ${target} APPEND_STRING
         PROPERTY LINK_FLAGS " ${dicom_common_link_flags}"
         )
     endforeach()


### PR DESCRIPTION
The *.umd.wasm files are identical to the *.wasm files. Have the .umd.js
bindings use the *.wasm WebAssembly files. This cuts the package size
roughly in half to keep us under the 100 MB jsDelivr limit.
