### PR TITLE
pipeline full path

### DIFF
--- a/doc/content/docs/itk_js_to_itk_wasm_migration_guide.md
+++ b/doc/content/docs/itk_js_to_itk_wasm_migration_guide.md
@@ -73,7 +73,7 @@ In the [Webpack Example](https://github.com/InsightSoftwareConsortium/itk-wasm/t
 
 ```js
 const itkConfig = {
-  webWorkersUrl: '/itk/web-workers',
+  pipelineWorkerUrl: '/itk/web-workers/bundles/pipeline-worker.js',
   imageIOUrl: '/itk/image-io',
   meshIOUrl: '/itk/mesh-io',
   pipelinesUrl: '/itk/pipelines',

--- a/src/core/internal/createWebWorkerPromise.ts
+++ b/src/core/internal/createWebWorkerPromise.ts
@@ -9,7 +9,7 @@ interface createWebWorkerPromiseResult {
 }
 
 // Internal function to create a web worker promise
-async function createWebWorkerPromise (name: 'pipeline', existingWorker: Worker | null): Promise<createWebWorkerPromiseResult> {
+async function createWebWorkerPromise (existingWorker: Worker | null): Promise<createWebWorkerPromiseResult> {
   if (existingWorker != null) {
     const webworkerPromise = new WebworkerPromise(existingWorker)
     return await Promise.resolve({ webworkerPromise, worker: existingWorker })
@@ -20,36 +20,17 @@ async function createWebWorkerPromise (name: 'pipeline', existingWorker: Worker 
   // importScripts / UMD is required over dynamic ESM import until Firefox
   // adds worker dynamic import support:
   // https://bugzilla.mozilla.org/show_bug.cgi?id=1540913
-  // switch (name) {
-  // case 'pipeline':
   // worker = new Worker(new URL('../../web-workers/pipeline.worker.js', import.meta.url))
-  // break
-  // default:
-  // throw Error('Unsupported web worker type')
-  // }
   const webWorkersUrl = config.webWorkersUrl
   const min = 'min-'
   // debug
   // const min = ''
 
   if (webWorkersUrl.startsWith('http')) {
-    switch (name) {
-      case 'pipeline': {
-        const response = await axios.get(`${webWorkersUrl}/${min}bundles/pipeline.worker.js`, { responseType: 'blob' })
-        worker = new Worker(URL.createObjectURL(response.data as Blob))
-        break
-      }
-      default:
-        throw Error('Unsupported web worker type')
-    }
+    const response = await axios.get(`${webWorkersUrl}/${min}bundles/pipeline.worker.js`, { responseType: 'blob' })
+    worker = new Worker(URL.createObjectURL(response.data as Blob))
   } else {
-    switch (name) {
-      case 'pipeline':
-        worker = new Worker(`${webWorkersUrl}/${min}bundles/pipeline.worker.js`)
-        break
-      default:
-        throw Error('Unsupported web worker type')
-    }
+    worker = new Worker(`${webWorkersUrl}/${min}bundles/pipeline.worker.js`)
   }
 
   const webworkerPromise = new WebworkerPromise(worker)

--- a/src/core/internal/createWebWorkerPromise.ts
+++ b/src/core/internal/createWebWorkerPromise.ts
@@ -16,21 +16,37 @@ async function createWebWorkerPromise (existingWorker: Worker | null): Promise<c
   }
 
   let worker = null
-  // Enable bundlers, e.g. WebPack, to see these paths at build time
-  // importScripts / UMD is required over dynamic ESM import until Firefox
-  // adds worker dynamic import support:
-  // https://bugzilla.mozilla.org/show_bug.cgi?id=1540913
-  // worker = new Worker(new URL('../../web-workers/pipeline.worker.js', import.meta.url))
   const webWorkersUrl = config.webWorkersUrl
-  const min = 'min-'
-  // debug
-  // const min = ''
+  if (typeof webWorkersUrl !== 'undefined') {
+    console.warn('itkConfig webWorkersUrl is deprecated. Please use pipelineWorkerUrl with the full path to the pipeline worker.')
+    const min = 'min-'
+    // debug
+    // const min = ''
 
-  if (webWorkersUrl.startsWith('http')) {
-    const response = await axios.get(`${webWorkersUrl}/${min}bundles/pipeline.worker.js`, { responseType: 'blob' })
-    worker = new Worker(URL.createObjectURL(response.data as Blob))
+    const webWorkerString = webWorkersUrl as string
+    if (webWorkerString.startsWith('http')) {
+      const response = await axios.get(`${webWorkerString}/${min}bundles/pipeline.worker.js`, { responseType: 'blob' })
+      worker = new Worker(URL.createObjectURL(response.data as Blob))
+    } else {
+      worker = new Worker(`${webWorkerString}/${min}bundles/pipeline.worker.js`)
+    }
+  } else if (config.pipelineWorkerUrl === null) {
+    // Use the version built with the bundler
+    //
+    // Bundlers, e.g. WebPack, see these paths at build time
+    //
+    // importScripts / UMD is required over dynamic ESM import until Firefox
+    // adds worker dynamic import support:
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1540913
+    worker = new Worker(new URL('../../web-workers/pipeline.worker.js', import.meta.url))
   } else {
-    worker = new Worker(`${webWorkersUrl}/${min}bundles/pipeline.worker.js`)
+    const pipelineWorkerUrl = config.pipelineWorkerUrl
+    if (pipelineWorkerUrl.startsWith('http')) {
+      const response = await axios.get(pipelineWorkerUrl, { responseType: 'blob' })
+      worker = new Worker(URL.createObjectURL(response.data as Blob))
+    } else {
+      worker = new Worker(pipelineWorkerUrl)
+    }
   }
 
   const webworkerPromise = new WebworkerPromise(worker)

--- a/src/io/internal/pipelines/image/ConvertImage/CMakeLists.txt
+++ b/src/io/internal/pipelines/image/ConvertImage/CMakeLists.txt
@@ -117,7 +117,7 @@ set(imageios_WebAssemblyInterface itkWASMImageIO itkWASMZstdImageIO)
 set(imageio_id_itkWASMImageIO 21)
 set(imageio_id_itkWASMZstdImageIO 22)
 
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1)
+set(ITK_NO_IMAGEIO_FACTORY_REGISTER_MANAGER 1)
 set(ImageIOIndex_ARRAY "")
 foreach(io_module ${WebAssemblyInterface_ImageIOModules} WebAssemblyInterface)
   if (DEFINED WebAssemblyInterface_INCLUDE_DIRS)

--- a/src/io/internal/pipelines/mesh/ConvertMesh/CMakeLists.txt
+++ b/src/io/internal/pipelines/mesh/ConvertMesh/CMakeLists.txt
@@ -42,7 +42,7 @@ set(meshios_WebAssemblyInterface itkWASMMeshIO itkWASMZstdMeshIO)
 set(meshio_id_itkWASMMeshIO 7)
 set(meshio_id_itkWASMZstdMeshIO 8)
 
-set(ITK_NO_IO_FACTORY_REGISTER_MANAGER 1)
+set(ITK_NO_MESHIO_FACTORY_REGISTER_MANAGER 1)
 set(MeshIOIndex_ARRAY "")
 foreach(io_module ${WebAssemblyInterface_MeshIOModules} WebAssemblyInterface)
   if (DEFINED WebAssemblyInterface_INCLUDE_DIRS)

--- a/src/io/meshToPolyData.ts
+++ b/src/io/meshToPolyData.ts
@@ -8,7 +8,7 @@ import config from '../itkConfig.js'
 
 async function meshToPolyData (webWorker: Worker | null, mesh: Mesh): Promise<{ polyData: PolyData, webWorker: Worker }> {
   let worker = webWorker
-  const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise('pipeline', worker)
+  const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise(worker)
   worker = usedWorker
 
   const args = ['0', '0', '--memory-io']

--- a/src/io/polyDataToMesh.ts
+++ b/src/io/polyDataToMesh.ts
@@ -8,7 +8,7 @@ import config from '../itkConfig.js'
 
 async function polyDataToMesh (webWorker: Worker | null, polyData: PolyData): Promise<{ mesh: Mesh, webWorker: Worker }> {
   let worker = webWorker
-  const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise('pipeline', worker)
+  const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise(worker)
   worker = usedWorker
 
   const args = ['0', '0', '--memory-io']

--- a/src/io/readDICOMTagsArrayBuffer.ts
+++ b/src/io/readDICOMTagsArrayBuffer.ts
@@ -10,7 +10,6 @@ import InterfaceTypes from '../core/InterfaceTypes.js'
 async function readDICOMTagsArrayBuffer (webWorker: Worker, arrayBuffer: ArrayBuffer, tags: string[] | null = null): Promise<ReadDICOMTagsResult> {
   let worker = webWorker
   const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise(
-    'pipeline',
     worker
   )
   worker = usedWorker

--- a/src/io/readImageArrayBuffer.ts
+++ b/src/io/readImageArrayBuffer.ts
@@ -9,7 +9,7 @@ import ReadImageResult from './ReadImageResult.js'
 
 async function readImageArrayBuffer (webWorker: Worker | null, arrayBuffer: ArrayBuffer, fileName: string, mimeType: string): Promise<ReadImageResult> {
   let worker = webWorker
-  const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise('pipeline', worker)
+  const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise(worker)
   worker = usedWorker
 
   const filePath = `./${fileName}`

--- a/src/io/readImageDICOMArrayBufferSeries.ts
+++ b/src/io/readImageDICOMArrayBufferSeries.ts
@@ -17,7 +17,6 @@ const workerFunction = async (
 ): Promise<ReadImageResult> => {
   let worker = webWorker
   const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise(
-    'pipeline',
     worker
   )
   worker = usedWorker

--- a/src/io/readMeshArrayBuffer.ts
+++ b/src/io/readMeshArrayBuffer.ts
@@ -9,7 +9,7 @@ import ReadMeshResult from './ReadMeshResult.js'
 
 async function readMeshArrayBuffer (webWorker: Worker | null, arrayBuffer: ArrayBuffer, fileName: string, mimeType: string): Promise<ReadMeshResult> {
   let worker = webWorker
-  const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise('pipeline', worker)
+  const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise(worker)
   worker = usedWorker
 
   const filePath = `./${fileName}`

--- a/src/io/writeImageArrayBuffer.ts
+++ b/src/io/writeImageArrayBuffer.ts
@@ -16,7 +16,7 @@ async function writeImageArrayBuffer (webWorker: Worker | null, image: Image, fi
   }
 
   let worker = webWorker
-  const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise('pipeline', worker)
+  const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise(worker)
   worker = usedWorker
 
   const filePath = `./${fileName}`

--- a/src/io/writeMeshArrayBuffer.ts
+++ b/src/io/writeMeshArrayBuffer.ts
@@ -16,7 +16,7 @@ async function writeMeshArrayBuffer (webWorker: Worker | null, mesh: Mesh, fileN
   }
 
   let worker = webWorker
-  const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise('pipeline', worker)
+  const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise(worker)
   worker = usedWorker
 
   const filePath = `./${fileName}`

--- a/src/itkConfig.ts
+++ b/src/itkConfig.ts
@@ -1,7 +1,8 @@
 const version = '1.0.0-b.5'
 
 const itkConfig = {
-  webWorkersUrl: `https://cdn.jsdelivr.net/npm/itk-wasm@${version}/dist/web-workers`,
+  webWorkersUrl: undefined,
+  pipelineWorkerUrl: `https://cdn.jsdelivr.net/npm/itk-wasm@${version}/dist/web-workers/min-bundles/pipeline.worker.js`,
   imageIOUrl: `https://cdn.jsdelivr.net/npm/itk-image-io@${version}`,
   meshIOUrl: `https://cdn.jsdelivr.net/npm/itk-mesh-io@${version}`,
   pipelinesUrl: `https://cdn.jsdelivr.net/npm/itk-wasm@${version}/dist/pipeline`

--- a/src/itkConfigCDN.js
+++ b/src/itkConfigCDN.js
@@ -1,5 +1,5 @@
 const itkConfig = {
-  webWorkersUrl: __webpack_public_path__ + 'itk-wasm@' + __itk_version__ + '/dist/web-workers', // eslint-disable-line no-undef
+  pipelineWorkerUrl: __webpack_public_path__ + 'itk-wasm@' + __itk_version__ + '/dist/web-workers/bundles/pipeline.worker.js', // eslint-disable-line no-undef
   imageIOUrl: __webpack_public_path__ + 'itk-image-io@' + __itk_version__, // eslint-disable-line no-undef
   meshIOUrl: __webpack_public_path__ + 'itk-mesh-io@' + __itk_version__, // eslint-disable-line no-undef
   pipelinesUrl: __webpack_public_path__ + 'itk-wasm@' + __itk_version__ + '/dist/pipeline', // eslint-disable-line no-undef

--- a/src/pipeline/runPipeline.ts
+++ b/src/pipeline/runPipeline.ts
@@ -43,7 +43,7 @@ async function runPipeline (webWorker: Worker | null | boolean, pipelinePath: st
     return result
   }
   let worker = webWorker
-  const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise('pipeline', worker as Worker | null)
+  const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise(worker as Worker | null)
   worker = usedWorker
   const transferables: ArrayBuffer[] = []
   if (!(inputs == null) && inputs.length > 0) {

--- a/src/web-workers/ITKConfig.ts
+++ b/src/web-workers/ITKConfig.ts
@@ -1,4 +1,6 @@
 interface ITKConfig {
+  webWorkersUrl?: string
+  pipelineWorkerUrl?: string
   pipelinesUrl: string
   imageIOUrl: string
   meshIOUrl: string

--- a/test/browser/config/itkConfigBrowserTest.js
+++ b/test/browser/config/itkConfigBrowserTest.js
@@ -1,5 +1,5 @@
 const itkConfig = {
-  webWorkersUrl: __BASE_PATH__ + '/dist/web-workers', // eslint-disable-line no-undef
+  pipelineWorkerUrl: __BASE_PATH__ + '/dist/web-workers/bundles/pipeline.worker.js', // eslint-disable-line no-undef
   imageIOUrl: __BASE_PATH__ + '/dist/image-io', // eslint-disable-line no-undef
   meshIOUrl: __BASE_PATH__ + '/dist/mesh-io', // eslint-disable-line no-undef
   pipelinesUrl: __BASE_PATH__ + '/dist/pipeline' // eslint-disable-line no-undef


### PR DESCRIPTION
- refactor(createWebWorkerPromise): Remove name argument
- build(Convert{Image,Mesh}): Update factory register manager CMake variables
- refactor(createWebWorkerPromise): Use pipelineWorkerUrl with full path to worker
