### PR TITLE
build(libcbor): Remove target_include_directories with build tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,8 @@ FetchContent_Declare(
 
 set(libcbor_GIT_REPOSITORY "https://github.com/PJK/libcbor")
 set(libcbor_GIT_REPOSITORY "https://github.com/thewtex/libcbor")
-# v0.9.0 + CMake + WASI
-set(libcbor_GIT_TAG "edb816cddf7e254e0f94c508ae3a6903430e3c62")
+# v0.9.0 + CMake + WASI + target_include_directory
+set(libcbor_GIT_TAG "8bfdc898e8391f1e9ffec147ee1321bb1d432816")
 FetchContent_Declare(
   libcbor
   GIT_REPOSITORY ${libcbor_GIT_REPOSITORY}


### PR DESCRIPTION
Address:

  Make Error in /home/matt/bin/ITK2-GCC-Release/_deps/libcbor-src/src/CMakeLists.txt:
    Target "cbor" INTERFACE_INCLUDE_DIRECTORIES property contains path:

      "/home/matt/bin/ITK2-GCC-Release/_deps/libcbor-src/src"

    which is prefixed in the build directory.
