### PR TITLE
ENH: return sorted file list when reading DICOM series

### DIFF
--- a/src/io/ReadImageFileSeriesResult.ts
+++ b/src/io/ReadImageFileSeriesResult.ts
@@ -4,6 +4,7 @@ import WorkerPool from '../core/WorkerPool.js'
 interface ReadImageFileSeriesResult {
   image: Image
   webWorkerPool: WorkerPool
+  orderedFileNames?: Array<string>
 }
 
 export default ReadImageFileSeriesResult

--- a/src/io/ReadImageResult.ts
+++ b/src/io/ReadImageResult.ts
@@ -3,6 +3,7 @@ import Image from '../core/Image.js'
 interface ReadImageResult {
   image: Image
   webWorker: Worker
+  orderedFileNames?: Array<string>
 }
 
 export default ReadImageResult

--- a/src/io/internal/pipelines/image/ReadDICOM/ReadImageDICOMFileSeries.cxx
+++ b/src/io/internal/pipelines/image/ReadDICOM/ReadImageDICOMFileSeries.cxx
@@ -30,6 +30,7 @@
 
 #include "itkPipeline.h"
 #include "itkOutputImage.h"
+#include "itkOutputTextStream.h"
 
 class CustomSerieHelper: public gdcm::SerieHelper
 {
@@ -194,6 +195,9 @@ int runPipeline(itk::wasm::Pipeline & pipeline, std::vector<std::string> & input
   OutputImageType outputImage;
   pipeline.add_option("-o,--output-image", outputImage, "Output image volume")->required();
 
+  itk::wasm::OutputTextStream outputFilenames;
+  auto outputFilenamesOption = pipeline.add_option("--output-filenames", outputFilenames, "Output sorted filenames.");
+
   ITK_WASM_PARSE(pipeline);
 
   typedef itk::QuickDICOMImageSeriesReader< ImageType > ReaderType;
@@ -201,7 +205,7 @@ int runPipeline(itk::wasm::Pipeline & pipeline, std::vector<std::string> & input
   reader->SetMetaDataDictionaryArrayUpdate(false);
 
   if (!singleSortedSeries)
-    {
+  {
     std::unique_ptr<CustomSerieHelper> serieHelper(new CustomSerieHelper());
     for (const std::string & fileName: inputFileNames)
     {
@@ -257,11 +261,21 @@ int runPipeline(itk::wasm::Pipeline & pipeline, std::vector<std::string> & input
     }
 
     reader->SetFileNames(fileNames);
-    }
+  }
   else
-    {
+  {
     reader->SetFileNames(inputFileNames);
+  }
+
+  // copy sorted filenames as additional output
+  if(!outputFilenamesOption->empty())
+  {
+    auto finalFileList = reader->GetFileNames();
+    for (auto f = finalFileList.begin(); f != finalFileList.end(); ++f)
+    {
+      outputFilenames.Get() << *f << ":";
     }
+  }
 
   auto gdcmImageIO = itk::GDCMImageIO::New();
   reader->SetImageIO(gdcmImageIO);
@@ -279,16 +293,25 @@ int main (int argc, char * argv[])
   std::vector<std::string> inputFileNames;
   pipeline.add_option("-i,--input-images", inputFileNames, "File names in the series")->required()->check(CLI::ExistingFile)->expected(1,-1);
 
+  // We are interested in reading --input-images beforehand.
+  // We need to add and then remove other options in order to do ITK_WASM_PARSE twice (once here in main, and then again in runPipeline)
   bool singleSortedSeries = false;
   auto sortedOption = pipeline.add_flag("-s,--single-sorted-series", singleSortedSeries, "There is a single sorted series in the files");
 
+  // Type is not important here, its just a dummy placeholder to be added and then removed.
   std::string outputImage;
   auto outputImageOption = pipeline.add_option("-o,--output-image", outputImage, "Output image volume")->required();
 
+  // Type is not important here, its just a dummy placeholder to be added and then removed.
+  std::string outputFilenames;
+  auto outputFilenamesOption = pipeline.add_option("--output-filenames", outputFilenames, "Output sorted filenames");
+
   ITK_WASM_PARSE(pipeline);
 
+  // Remove added dummy options. runPipeline will add the real options later.
   pipeline.remove_option(sortedOption);
   pipeline.remove_option(outputImageOption);
+  pipeline.remove_option(outputFilenamesOption);
 
   auto gdcmImageIO = itk::GDCMImageIO::New();
 

--- a/src/io/readImageDICOMArrayBufferSeries.ts
+++ b/src/io/readImageDICOMArrayBufferSeries.ts
@@ -21,7 +21,7 @@ const workerFunction = async (
   )
   worker = usedWorker
 
-  const args = ['--memory-io', '--output-image', '0', '--input-images']
+  const args = ['--memory-io', '--output-image', '0', '--output-filenames', '1', '--input-images']
   fileDescriptions.forEach((desc) => {
     args.push(`./${desc.path}`)
   })
@@ -29,7 +29,8 @@ const workerFunction = async (
     args.push('--single-sorted-series')
   }
   const outputs = [
-    { type: InterfaceTypes.Image }
+    { type: InterfaceTypes.Image },
+    { type: InterfaceTypes.TextStream },
   ]
   const inputs = fileDescriptions.map((fd) => {
     return { type: InterfaceTypes.BinaryFile, data: fd }
@@ -54,7 +55,8 @@ const workerFunction = async (
     inputs
   }
   const result: PipelineResult = await webworkerPromise.postMessage(message, transferables)
-  return { image: result.outputs[0].data as Image, webWorker: worker }
+  const orderedFileNames = result.outputs[1].data.data.split(':')
+  return { image: result.outputs[0].data as Image, orderedFileNames, webWorker: worker }
 }
 const numberOfWorkers = typeof globalThis.navigator?.hardwareConcurrency === 'number' ? globalThis.navigator.hardwareConcurrency : 4
 const workerPool = new WorkerPool(numberOfWorkers, workerFunction)
@@ -63,10 +65,12 @@ const seriesBlockSize = 8
 
 const readImageDICOMArrayBufferSeries = async (
   arrayBuffers: ArrayBuffer[],
-  singleSortedSeries = false
+  singleSortedSeries = false,
+  fileNames?: Array<string>
 ): Promise<ReadImageFileSeriesResult> => {
+  const validFileNames = fileNames && fileNames.length == arrayBuffers.length
   const fileDescriptions = arrayBuffers.map((ab, index) => {
-    return { path: `${index}.dcm`, data: new Uint8Array(ab) }
+    return { path: validFileNames? fileNames[index] : `${index}.dcm`, data: new Uint8Array(ab) }
   })
   if (singleSortedSeries) {
     const taskArgsArray = []
@@ -81,7 +85,7 @@ const readImageDICOMArrayBufferSeries = async (
   } else {
     const taskArgsArray = [[fileDescriptions, singleSortedSeries]]
     const results = await workerPool.runTasks(taskArgsArray).promise
-    return { image: results[0].image, webWorkerPool: workerPool }
+    return { image: results[0].image, webWorkerPool: workerPool, orderedFileNames: results[0].orderedFileNames }
   }
 }
 

--- a/src/io/readImageDICOMFileSeries.ts
+++ b/src/io/readImageDICOMFileSeries.ts
@@ -12,7 +12,8 @@ const readImageDICOMFileSeries = async (
   })
   const fileContents: ArrayBuffer[] = await Promise.all(fetchFileContents)
 
-  return await readImageDICOMArrayBufferSeries(fileContents, singleSortedSeries)
+  const fileNames = Array.from(fileList, (file) => file.name);
+  return await readImageDICOMArrayBufferSeries(fileContents, singleSortedSeries, fileNames)
 }
 
 export default readImageDICOMFileSeries


### PR DESCRIPTION
The functions `readImageDICOMFileSeries` and `readImageDICOMArrayBufferSeries`
have an additional side effect that it sorts / orders the files
(particularly DICOM files) based on a pre-defined logic in `gdcm`.
However, this information is not related to the caller in any form.

Add `Array<string>` as the ordered list of filenames as additional output.