### PR TITLE
feat(ReadImageDICOM): Return sorted file list when reading DICOM series

### DIFF
--- a/src/core/Image.ts
+++ b/src/core/Image.ts
@@ -13,7 +13,7 @@ class Image {
 
   size: number[]
 
-  metadata: Record<string, string | number | number[] | number[][]>
+  metadata: Record<string, string | string[] | number | number[] | number[][]>
 
   data: null | TypedArray
 

--- a/src/io/readImageDICOMFileSeries.ts
+++ b/src/io/readImageDICOMFileSeries.ts
@@ -12,7 +12,8 @@ const readImageDICOMFileSeries = async (
   })
   const fileContents: ArrayBuffer[] = await Promise.all(fetchFileContents)
 
-  return await readImageDICOMArrayBufferSeries(fileContents, singleSortedSeries)
+  const fileNames = Array.from(fileList, (file) => file.name)
+  return await readImageDICOMArrayBufferSeries(fileContents, singleSortedSeries, fileNames)
 }
 
 export default readImageDICOMFileSeries


### PR DESCRIPTION
This is to redo PR https://github.com/InsightSoftwareConsortium/itk-wasm/pull/584 with proper commit message format.

The functions readImageDICOMFileSeries and readImageDICOMArrayBufferSeries
have an additional side effect that it sorts / orders the files
(particularly DICOM files) based on a pre-defined logic in gdcm.
However, this information is not related to the caller in any form.

Add Array<string> as the ordered list of filenames as additional output.