### PR TITLE
build(Docker): update dockcross for Apple Silicon builds

### DIFF
--- a/src/docker/itk-wasm-base/Dockerfile
+++ b/src/docker/itk-wasm-base/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=dockcross/web-wasm
-FROM $BASE_IMAGE:20220612-21326cc
+FROM $BASE_IMAGE:20220705-d45d925
 ARG BASE_IMAGE
 
 LABEL maintainer="Matt McCormick <matt.mccormick@kitware.com>"


### PR DESCRIPTION
Requires the latest Docker Desktop. A few warnings about the
architectures may still be present.
