### PR TITLE
chore(commitlint): allow upper-case subject

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,6 +217,17 @@
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"
-    ]
+    ],
+    "rules": {
+      "subject-case": [
+        2,
+        "never",
+        [
+          "start-case",
+          "pascal-case",
+          "upper-case"
+        ]
+      ]
+    }
   }
 }


### PR DESCRIPTION
This allows for a subject line to start with an upper case.