### PR TITLE
fix(worker): Ensure worker promises are reused

### DIFF
--- a/src/core/internal/createWebWorkerPromise.ts
+++ b/src/core/internal/createWebWorkerPromise.ts
@@ -8,11 +8,24 @@ interface createWebWorkerPromiseResult {
   worker: Worker
 }
 
+interface itkWorker extends Worker {
+  workerPromise?: typeof WebworkerPromise
+}
+
 // Internal function to create a web worker promise
 async function createWebWorkerPromise (existingWorker: Worker | null): Promise<createWebWorkerPromiseResult> {
+  let workerPromise: typeof WebworkerPromise
   if (existingWorker != null) {
-    const webworkerPromise = new WebworkerPromise(existingWorker)
-    return await Promise.resolve({ webworkerPromise, worker: existingWorker })
+    // See if we have a worker promise attached the worker, if so reuse it. This ensures
+    // that we can safely reuse the worker without issues.
+    const itkWebWorker = existingWorker as itkWorker;
+    if (itkWebWorker.workerPromise !== undefined) {
+      workerPromise = itkWebWorker.workerPromise;
+    } else {
+      workerPromise = new WebworkerPromise(existingWorker);
+    }
+
+    return await Promise.resolve({ webworkerPromise: workerPromise, worker: existingWorker })
   }
 
   let worker = null
@@ -49,8 +62,13 @@ async function createWebWorkerPromise (existingWorker: Worker | null): Promise<c
     }
   }
 
-  const webworkerPromise = new WebworkerPromise(worker)
-  return { webworkerPromise, worker }
+  const webworkerPromise = new WebworkerPromise(worker);
+
+  // Attach the worker promise to the worker, so if the worker is reused we can
+  // also reuse the the worker promise.
+  const itkWebWorker = (worker as itkWorker);
+  itkWebWorker.workerPromise = webworkerPromise;
+  return { webworkerPromise, worker: itkWebWorker }
 }
 
 export default createWebWorkerPromise


### PR DESCRIPTION
When running task in a worker in "parallel" the access to the worker must be performed through the same worker promise otherwise requests and responses can get interleaved. This situation can occur if for example `Promise.all(...)` is used to run the tasks in the worker. To prevent this issue we attach the work promise to the worker, so it can be used again if the worker is reused.