### PR TITLE
feat: expose version

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -36,3 +36,6 @@ export { default as WorkerPool } from './WorkerPool.js'
 export { default as WorkerPoolFunction } from './WorkerPoolFunction.js'
 export { default as WorkerPoolProgressCallback } from './WorkerPoolProgressCallback.js'
 export { default as WorkerPoolRunTasksResult } from './WorkerPoolRunTasksResult.js'
+
+const version = '1.0.0-b.18';
+export { version };

--- a/src/itkConfig.ts
+++ b/src/itkConfig.ts
@@ -1,4 +1,4 @@
-import { version } from '.'
+import { version } from './index.js'
 
 const itkConfig = {
   webWorkersUrl: undefined,

--- a/src/itkConfig.ts
+++ b/src/itkConfig.ts
@@ -1,4 +1,4 @@
-const version = '1.0.0-b.18'
+import { version } from '.'
 
 const itkConfig = {
   webWorkersUrl: undefined,

--- a/update-versions.cjs
+++ b/update-versions.cjs
@@ -21,5 +21,5 @@ function rewriteVersion(filename) {
   fs.writeFileSync(filename, lines.join('\n'))
 }
 
-rewriteVersion('dist/itkConfig.js')
+rewriteVersion('dist/core/index.js')
 rewriteVersion('dist/itkConfigDevelopment.js')


### PR DESCRIPTION
The idea is to be able to do `import { version } from 'itk-wasm'` as it can be useful to know the version to use it in the build process to version the assets and invalidate caches.