### PR TITLE
ci(repository-url): Remove git+ protocol prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/InsightSoftwareConsortium/itk-wasm.git"
+    "url": "https://github.com/InsightSoftwareConsortium/itk-wasm.git"
   },
   "keywords": [
     "itk",


### PR DESCRIPTION
GitHub primarily supports the https protocol.
