### PR TITLE
build(ExportMap): Add "default" entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
       "browser": "./dist/browser/index.js",
       "import": "./dist/node/index.js",
       "umd": "./dist/umd/itk-wasm.js",
-      "package.json": "./package.json"
+      "package.json": "./package.json",
+      "default": "./dist/index.js"
     }
   },
   "type": "module",


### PR DESCRIPTION
https://nodejs.org/api/packages.html#conditional-exports

> "default" - the generic fallback that always matches. Can be a CommonJS or ES module file. This condition should always come last.