### PR TITLE
Feature: add structured-report-to-html operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,21 @@ build-wasi
 src/io/internal/ImageIOIndex.ts
 src/io/internal/MeshIOIndex.ts
 
-dist
+dist/*
+!dist/dicom
+
+dist/dicom/*
+!dist/dicom/cypress
+!dist/dicom/dist
+!dist/dicom/src
+!dist/dicom/test
+
+dist/dicom/dist/*
+!dist/dicom/dist/demo
+
+dist/dicom/dist/demo/*
+!dist/dicom/dist/demo/app.js
+
 node_modules
 .DS_Store
 yarn.lock

--- a/dist/dicom/src/StructuredReportToHtmlNodeResult.ts
+++ b/dist/dicom/src/StructuredReportToHtmlNodeResult.ts
@@ -1,0 +1,7 @@
+interface StructuredReportToHtmlNodeResult {
+  /** Output text file */
+  outputText: string
+
+}
+
+export default StructuredReportToHtmlNodeResult

--- a/dist/dicom/src/StructuredReportToHtmlOptions.ts
+++ b/dist/dicom/src/StructuredReportToHtmlOptions.ts
@@ -1,0 +1,125 @@
+interface StructuredReportToHtmlOptions {
+  /** read file format only */
+  readFileOnly?: boolean
+
+  /** read data set without file meta information */
+  readDataset?: boolean
+
+  /** use TS recognition (default) */
+  readXferAuto?: boolean
+
+  /** ignore TS specified in the file meta header */
+  readXferDetect?: boolean
+
+  /** read with explicit VR little endian TS */
+  readXferLittle?: boolean
+
+  /** read with explicit VR big endian TS */
+  readXferBig?: boolean
+
+  /** read with implicit VR little endian TS */
+  readXferImplicit?: boolean
+
+  /** show currently processed content item */
+  processingDetails?: boolean
+
+  /** accept unknown/missing relationship type */
+  unknownRelationship?: boolean
+
+  /** accept invalid content item value
+(e.g. violation of VR or VM definition) */
+  invalidItemValue?: boolean
+
+  /** ignore relationship content constraints */
+  ignoreConstraints?: boolean
+
+  /** do not abort on content item errors, just warn
+(e.g. missing value type specific attributes) */
+  ignoreItemErrors?: boolean
+
+  /** skip invalid content items (incl. sub-tree) */
+  skipInvalidItems?: boolean
+
+  /** disable check for VR-conformant string values */
+  disableVrChecker?: boolean
+
+  /** require declaration of ext. charset (default) */
+  charsetRequire?: boolean
+
+  /** [c]harset: string, assume charset c if no extended charset declared */
+  charsetAssume?: string
+
+  /** check all data elements with string values
+(default: only PN, LO, LT, SH, ST, UC and UT) */
+  charsetCheckAll?: boolean
+
+  /** convert all element values that are affected
+by Specific Character Set (0008,0005) to UTF-8 */
+  convertToUtf8?: boolean
+
+  /** use only HTML version 3.2 compatible features */
+  html32?: boolean
+
+  /** allow all HTML version 4.01 features (default) */
+  html40?: boolean
+
+  /** comply with XHTML version 1.1 specification */
+  xhtml11?: boolean
+
+  /** add reference to SGML document type definition */
+  addDocumentType?: boolean
+
+  /** URL: string. Add reference to specified CSS to document */
+  cssReference?: string
+
+  /** [f]ilename: string. Embed content of specified CSS into document */
+  cssFile?: string
+
+  /** expand short content items inline (default) */
+  expandInline?: boolean
+
+  /** never expand content items inline */
+  neverExpandInline?: boolean
+
+  /** always expand content items inline */
+  alwaysExpandInline?: boolean
+
+  /** render full data of content items */
+  renderFullData?: boolean
+
+  /** render section titles inline, not separately */
+  sectionTitleInline?: boolean
+
+  /** use document type as document title (default) */
+  documentTypeTitle?: boolean
+
+  /** use patient information as document title */
+  patientInfoTitle?: boolean
+
+  /** do not render general document information */
+  noDocumentHeader?: boolean
+
+  /** render codes in continuous text blocks */
+  renderInlineCodes?: boolean
+
+  /** render code of concept names */
+  conceptNameCodes?: boolean
+
+  /** render code of numeric measurement units */
+  numericUnitCodes?: boolean
+
+  /** use code value as measurement unit (default) */
+  codeValueUnit?: boolean
+
+  /** use code meaning as measurement unit */
+  codeMeaningUnit?: boolean
+
+  /** render all codes (implies +Ci, +Cn and +Cu) */
+  renderAllCodes?: boolean
+
+  /** render code details as a tooltip (implies +Cc) */
+  codeDetailsTooltip?: boolean
+
+}
+
+export default StructuredReportToHtmlOptions

--- a/dist/dicom/src/StructuredReportToHtmlResult.ts
+++ b/dist/dicom/src/StructuredReportToHtmlResult.ts
@@ -1,0 +1,10 @@
+interface StructuredReportToHtmlResult {
+  /** WebWorker used for computation */
+  webWorker: Worker | null
+
+  /** Output text file */
+  outputText: string
+
+}
+
+export default StructuredReportToHtmlResult

--- a/dist/dicom/src/index.ts
+++ b/dist/dicom/src/index.ts
@@ -1,5 +1,15 @@
 
 
+import StructuredReportToHtmlResult from './StructuredReportToHtmlResult.js'
+export type { StructuredReportToHtmlResult }
+
+import StructuredReportToHtmlOptions from './StructuredReportToHtmlOptions.js'
+export type { StructuredReportToHtmlOptions }
+
+import structuredReportToHtml from './structuredReportToHtml.js'
+export { structuredReportToHtml }
+
+
 import StructuredReportToTextResult from './StructuredReportToTextResult.js'
 export type { StructuredReportToTextResult }
 

--- a/dist/dicom/src/indexNode.ts
+++ b/dist/dicom/src/indexNode.ts
@@ -1,5 +1,15 @@
 
 
+import StructuredReportToHtmlNodeResult from './StructuredReportToHtmlNodeResult.js'
+export type { StructuredReportToHtmlNodeResult }
+
+import StructuredReportToHtmlOptions from './StructuredReportToHtmlOptions.js'
+export type { StructuredReportToHtmlOptions }
+
+import structuredReportToHtmlNode from './structuredReportToHtmlNode.js'
+export { structuredReportToHtmlNode }
+
+
 import StructuredReportToTextNodeResult from './StructuredReportToTextNodeResult.js'
 export type { StructuredReportToTextNodeResult }
 

--- a/dist/dicom/src/structuredReportToHtml.ts
+++ b/dist/dicom/src/structuredReportToHtml.ts
@@ -1,0 +1,174 @@
+import {
+  TextStream,
+  InterfaceTypes,
+  runPipeline
+} from 'itk-wasm'
+
+import StructuredReportToHtmlOptions from './StructuredReportToHtmlOptions.js'
+import StructuredReportToHtmlResult from './StructuredReportToHtmlResult.js'
+
+/**
+ * Render DICOM SR file and data set to HTML/XHTML
+ *
+ * @param {Uint8Array} dicomFile - Input DICOM file
+ *
+ * @returns {Promise<StructuredReportToHtmlResult>} - result object
+ */
+async function structuredReportToHtml(
+  webWorker: null | Worker,
+  dicomFile: Uint8Array,
+  options: StructuredReportToHtmlOptions = {})
+    : Promise<StructuredReportToHtmlResult> {
+
+  const desiredOutputs = [
+    { type: InterfaceTypes.TextStream },
+  ]
+  const inputs = [
+    { type: InterfaceTypes.BinaryFile, data: { data: dicomFile, path: "file0" }  },
+  ]
+
+  const args = []
+  // Inputs
+  args.push('file0')
+  // Outputs
+  args.push('0')
+  // Options
+  args.push('--memory-io')
+  if (options.readFileOnly) {
+    args.push('--read-file-only')
+  }
+  if (options.readDataset) {
+    args.push('--read-dataset')
+  }
+  if (options.readXferAuto) {
+    args.push('--read-xfer-auto')
+  }
+  if (options.readXferDetect) {
+    args.push('--read-xfer-detect')
+  }
+  if (options.readXferLittle) {
+    args.push('--read-xfer-little')
+  }
+  if (options.readXferBig) {
+    args.push('--read-xfer-big')
+  }
+  if (options.readXferImplicit) {
+    args.push('--read-xfer-implicit')
+  }
+  if (options.processingDetails) {
+    args.push('--processing-details')
+  }
+  if (options.unknownRelationship) {
+    args.push('--unknown-relationship')
+  }
+  if (options.invalidItemValue) {
+    args.push('--invalid-item-value')
+  }
+  if (options.ignoreConstraints) {
+    args.push('--ignore-constraints')
+  }
+  if (options.ignoreItemErrors) {
+    args.push('--ignore-item-errors')
+  }
+  if (options.skipInvalidItems) {
+    args.push('--skip-invalid-items')
+  }
+  if (options.disableVrChecker) {
+    args.push('--disable-vr-checker')
+  }
+  if (options.charsetRequire) {
+    args.push('--charset-require')
+  }
+  if (options.charsetAssume) {
+    args.push('--charset-assume', '1')
+  }
+  if (options.charsetCheckAll) {
+    args.push('--charset-check-all')
+  }
+  if (options.convertToUtf8) {
+    args.push('--convert-to-utf8')
+  }
+  if (options.html32) {
+    args.push('--html-3.2')
+  }
+  if (options.html40) {
+    args.push('--html-4.0')
+  }
+  if (options.xhtml11) {
+    args.push('--xhtml-1.1')
+  }
+  if (options.addDocumentType) {
+    args.push('--add-document-type')
+  }
+  if (options.cssReference) {
+    args.push('--css-reference', '2')
+  }
+  if (options.cssFile) {
+    args.push('--css-file', '3')
+  }
+  if (options.expandInline) {
+    args.push('--expand-inline')
+  }
+  if (options.neverExpandInline) {
+    args.push('--never-expand-inline')
+  }
+  if (options.alwaysExpandInline) {
+    args.push('--always-expand-inline')
+  }
+  if (options.renderFullData) {
+    args.push('--render-full-data')
+  }
+  if (options.sectionTitleInline) {
+    args.push('--section-title-inline')
+  }
+  if (options.documentTypeTitle) {
+    args.push('--document-type-title')
+  }
+  if (options.patientInfoTitle) {
+    args.push('--patient-info-title')
+  }
+  if (options.noDocumentHeader) {
+    args.push('--no-document-header')
+  }
+  if (options.renderInlineCodes) {
+    args.push('--render-inline-codes')
+  }
+  if (options.conceptNameCodes) {
+    args.push('--concept-name-codes')
+  }
+  if (options.numericUnitCodes) {
+    args.push('--numeric-unit-codes')
+  }
+  if (options.codeValueUnit) {
+    args.push('--code-value-unit')
+  }
+  if (options.codeMeaningUnit) {
+    args.push('--code-meaning-unit')
+  }
+  if (options.renderAllCodes) {
+    args.push('--render-all-codes')
+  }
+  if (options.codeDetailsTooltip) {
+    args.push('--code-details-tooltip')
+  }
+
+  const pipelinePath = 'structured-report-to-html'
+
+  const {
+    webWorker: usedWebWorker,
+    returnValue,
+    stderr,
+    outputs
+  } = await runPipeline(webWorker, pipelinePath, args, desiredOutputs, inputs)
+  if (returnValue !== 0) {
+    throw new Error(stderr)
+  }
+
+  const result = {
+    webWorker: usedWebWorker as Worker,
+    outputText: (outputs[0].data as TextStream).data,
+  }
+  return result
+}
+
+export default structuredReportToHtml

--- a/dist/dicom/src/structuredReportToHtmlNode.ts
+++ b/dist/dicom/src/structuredReportToHtmlNode.ts
@@ -1,0 +1,173 @@
+import {
+  TextStream,
+  InterfaceTypes,
+  runPipelineNode
+} from 'itk-wasm'
+
+import StructuredReportToHtmlOptions from './StructuredReportToHtmlOptions.js'
+import StructuredReportToHtmlNodeResult from './StructuredReportToHtmlNodeResult.js'
+
+
+import path from 'path'
+
+/**
+ * Render DICOM SR file and data set to HTML/XHTML
+ *
+ * @param {Uint8Array} dicomFile - Input DICOM file
+ *
+ * @returns {Promise<StructuredReportToHtmlNodeResult>} - result object
+ */
+async function structuredReportToHtmlNode(  dicomFile: Uint8Array,
+  options: StructuredReportToHtmlOptions = {})
+    : Promise<StructuredReportToHtmlNodeResult> {
+
+  const desiredOutputs = [
+    { type: InterfaceTypes.TextStream },
+  ]
+  const inputs = [
+    { type: InterfaceTypes.BinaryFile, data: { data: dicomFile, path: "file0" }  },
+  ]
+
+  const args = []
+  // Inputs
+  args.push('file0')
+  // Outputs
+  args.push('0')
+  // Options
+  args.push('--memory-io')
+  if (options.readFileOnly) {
+    args.push('--read-file-only')
+  }
+  if (options.readDataset) {
+    args.push('--read-dataset')
+  }
+  if (options.readXferAuto) {
+    args.push('--read-xfer-auto')
+  }
+  if (options.readXferDetect) {
+    args.push('--read-xfer-detect')
+  }
+  if (options.readXferLittle) {
+    args.push('--read-xfer-little')
+  }
+  if (options.readXferBig) {
+    args.push('--read-xfer-big')
+  }
+  if (options.readXferImplicit) {
+    args.push('--read-xfer-implicit')
+  }
+  if (options.processingDetails) {
+    args.push('--processing-details')
+  }
+  if (options.unknownRelationship) {
+    args.push('--unknown-relationship')
+  }
+  if (options.invalidItemValue) {
+    args.push('--invalid-item-value')
+  }
+  if (options.ignoreConstraints) {
+    args.push('--ignore-constraints')
+  }
+  if (options.ignoreItemErrors) {
+    args.push('--ignore-item-errors')
+  }
+  if (options.skipInvalidItems) {
+    args.push('--skip-invalid-items')
+  }
+  if (options.disableVrChecker) {
+    args.push('--disable-vr-checker')
+  }
+  if (options.charsetRequire) {
+    args.push('--charset-require')
+  }
+  if (options.charsetAssume) {
+    args.push('--charset-assume', '1')
+  }
+  if (options.charsetCheckAll) {
+    args.push('--charset-check-all')
+  }
+  if (options.convertToUtf8) {
+    args.push('--convert-to-utf8')
+  }
+  if (options.html32) {
+    args.push('--html-3.2')
+  }
+  if (options.html40) {
+    args.push('--html-4.0')
+  }
+  if (options.xhtml11) {
+    args.push('--xhtml-1.1')
+  }
+  if (options.addDocumentType) {
+    args.push('--add-document-type')
+  }
+  if (options.cssReference) {
+    args.push('--css-reference', '2')
+  }
+  if (options.cssFile) {
+    args.push('--css-file', '3')
+  }
+  if (options.expandInline) {
+    args.push('--expand-inline')
+  }
+  if (options.neverExpandInline) {
+    args.push('--never-expand-inline')
+  }
+  if (options.alwaysExpandInline) {
+    args.push('--always-expand-inline')
+  }
+  if (options.renderFullData) {
+    args.push('--render-full-data')
+  }
+  if (options.sectionTitleInline) {
+    args.push('--section-title-inline')
+  }
+  if (options.documentTypeTitle) {
+    args.push('--document-type-title')
+  }
+  if (options.patientInfoTitle) {
+    args.push('--patient-info-title')
+  }
+  if (options.noDocumentHeader) {
+    args.push('--no-document-header')
+  }
+  if (options.renderInlineCodes) {
+    args.push('--render-inline-codes')
+  }
+  if (options.conceptNameCodes) {
+    args.push('--concept-name-codes')
+  }
+  if (options.numericUnitCodes) {
+    args.push('--numeric-unit-codes')
+  }
+  if (options.codeValueUnit) {
+    args.push('--code-value-unit')
+  }
+  if (options.codeMeaningUnit) {
+    args.push('--code-meaning-unit')
+  }
+  if (options.renderAllCodes) {
+    args.push('--render-all-codes')
+  }
+  if (options.codeDetailsTooltip) {
+    args.push('--code-details-tooltip')
+  }
+
+  const pipelinePath = path.join(path.dirname(import.meta.url.substring(7)), 'pipelines', 'structured-report-to-html')
+
+  const {
+    returnValue,
+    stderr,
+    outputs
+  } = await runPipelineNode(pipelinePath, args, desiredOutputs, inputs)
+  if (returnValue !== 0) {
+    throw new Error(stderr)
+  }
+
+  const result = {
+    outputText: (outputs[0].data as TextStream).data,
+  }
+  return result
+}
+
+export default structuredReportToHtmlNode

--- a/dist/dicom/test/node.js
+++ b/dist/dicom/test/node.js
@@ -1,6 +1,7 @@
 import fs from 'fs'
 import test from 'ava'
 import { structuredReportToTextNode } from '../dist/itk-dicom.node.js'
+import { structuredReportToHtmlNode } from '../dist/itk-dicom.node.js'
 
 test('structuredReportToText', async t => {
 
@@ -17,4 +18,29 @@ test('structuredReportToText', async t => {
   const { outputText: outputTextNoHeader } = await structuredReportToTextNode(dicomFile, { noDocumentHeader: true })
   t.assert(!outputTextNoHeader.includes('Comprehensive SR Document'))
   t.assert(outputTextNoHeader.includes('Breast Imaging Report'))
+})
+
+test('structuredReportToHtml', async t => {
+
+  const fileName = '88.33-comprehensive-SR.dcm'
+  const testFilePath = `../../build-emscripten/ExternalData/test/Input/${fileName}`
+
+  const dicomFileBuffer = fs.readFileSync(testFilePath)
+  const dicomFile = new Uint8Array(dicomFileBuffer)
+
+  const { outputText } = await structuredReportToHtmlNode(dicomFile)
+
+  t.assert(outputText.includes('Comprehensive SR Document'))
+  t.assert(outputText.includes('Breast Diagnosis 010001 (female, #BreastDx-01-0001)'))
+  t.assert(outputText.includes('PixelMed (XSLT from di3data csv extract)'))
+
+  const { outputText: outputTextNoHeader } = await structuredReportToHtmlNode(dicomFile, { noDocumentHeader: true })
+
+  t.assert(!outputTextNoHeader.includes('Breast Diagnosis 010001 (female, #BreastDx-01-0001)'))
+  t.assert(!outputTextNoHeader.includes('PixelMed (XSLT from di3data csv extract)'))
+
+  const { outputText: outputTextRenderAllCodes } = await structuredReportToHtmlNode(dicomFile, { renderAllCodes: true })
+
+  t.assert(outputTextRenderAllCodes.includes('Overall Assessment (111413, DCM)'))
+
 })

--- a/src/core/internal/camelCase.ts
+++ b/src/core/internal/camelCase.ts
@@ -1,7 +1,17 @@
 function camelCase (kebobCase: string): string {
-  return kebobCase.replace(/-([a-z])/g, (kk) => {
-    return kk[1].toUpperCase()
-  })
+  // make any alphabets that follows '-' an uppercase character, and remove the corresponding hyphen
+  let cameledParam = kebobCase.replace(/-([a-z])/g, (kk) => {
+    return kk[1].toUpperCase();
+  });
+
+  // remove all non-alphanumeric characters
+  const outParam = cameledParam.replace(/([^0-9a-z])/ig, '')
+
+  // check if resulting string is empty
+  if(outParam === '') {
+    console.error(`Resulting string is empty.`)
+  }
+  return outParam
 }
 
 export default camelCase

--- a/src/io/internal/pipelines/dicom/CMakeLists.txt
+++ b/src/io/internal/pipelines/dicom/CMakeLists.txt
@@ -14,8 +14,11 @@ set(wasm_modules )
 
 # diquant.cc required for odd linker error
 add_executable(structured-report-to-text structured-report-to-text.cxx diquant.cc)
+add_executable(structured-report-to-html structured-report-to-html.cxx diquant.cc)
 target_link_libraries(structured-report-to-text PUBLIC ${ITK_LIBRARIES})
+target_link_libraries(structured-report-to-html PUBLIC ${ITK_LIBRARIES})
 list(APPEND wasm_modules "structured-report-to-text")
+list(APPEND wasm_modules "structured-report-to-html")
 
 
 if (WASI AND DEFINED WebAssemblyInterface_BINARY_DIR)

--- a/src/io/internal/pipelines/dicom/structured-report-to-html.cxx
+++ b/src/io/internal/pipelines/dicom/structured-report-to-html.cxx
@@ -183,7 +183,7 @@ static OFCondition renderFile(STD_NAMESPACE ostream &out,
 #define LONGCOL 22
 
 
-int main(int argc, char *argv[])
+int main(int argc, char * argv[])
 {
   itk::wasm::Pipeline pipeline("structured-report-to-html", "Render DICOM SR file and data set to HTML/XHTML", argc, argv);
 
@@ -239,7 +239,7 @@ int main(int argc, char *argv[])
   bool charsetRequire{false};
   pipeline.add_flag("--charset-require", charsetRequire,    "require declaration of ext. charset (default)");
   std::string charsetAssumeValue;
-  pipeline.add_option("--charset-assume", charsetAssumeValue, "[c]harset: string, assume charset c if no extended charset declared");
+  pipeline.add_option("--charset-assume", charsetAssumeValue, "[c]harset: string, assume charset c if no extended charset declared")->type_name("INPUT_TEXT_STREAM");
   bool charsetCheckAll{false};
   pipeline.add_flag("--charset-check-all", charsetCheckAll, "check all data elements with string values\n(default: only PN, LO, LT, SH, ST, UC and UT)");
 #ifdef DCMTK_ENABLE_CHARSET_CONVERSION
@@ -256,10 +256,10 @@ int main(int argc, char *argv[])
 
   //   SubGroup("cascading style sheet (CSS), not with HTML 3.2:")
   std::string cssReferenceValue;
-  auto cssReferenceValueCliOption = pipeline.add_option("--css-reference", cssReferenceValue, "URL: string. Add reference to specified CSS to document");
+  auto cssReferenceValueCliOption = pipeline.add_option("--css-reference", cssReferenceValue, "URL: string. Add reference to specified CSS to document")->type_name("INPUT_TEXT_STREAM");
   cssReferenceValueCliOption->excludes(html32CliOption);
   std::string cssFileValue;
-  auto cssFileValueCliOption = pipeline.add_option("--css-file", cssFileValue, "[f]ilename: string. Embed content of specified CSS into document");
+  auto cssFileValueCliOption = pipeline.add_option("--css-file", cssFileValue, "[f]ilename: string. Embed content of specified CSS into document")->type_name("INPUT_TEXT_STREAM");
   cssFileValueCliOption->excludes(html32CliOption);
 
   //   SubGroup("general rendering:");

--- a/src/io/internal/pipelines/dicom/structured-report-to-html.cxx
+++ b/src/io/internal/pipelines/dicom/structured-report-to-html.cxx
@@ -1,0 +1,491 @@
+/*
+ *
+ *  Copyright (C) 2000-2016, OFFIS e.V.
+ *  All rights reserved.  See COPYRIGHT file for details.
+ *
+ *  This software and supporting documentation were developed by
+ *
+ *    OFFIS e.V.
+ *    R&D Division Health
+ *    Escherweg 2
+ *    D-26121 Oldenburg, Germany
+ *
+ *
+ *  Module: dcmsr
+ *
+ *  Author: Joerg Riesmeier
+ *
+ *  Purpose:
+ *    render the contents of a DICOM structured reporting file in HTML format
+ *
+ */
+
+
+#include "dcmtk/config/osconfig.h"    /* make sure OS specific configuration is included first */
+
+#include "dcmtk/dcmsr/dsrdoc.h"       /* for main interface class DSRDocument */
+
+#include "dcmtk/dcmdata/dctk.h"       /* for typical set of "dcmdata" headers */
+
+#include "dcmtk/ofstd/ofstream.h"
+#include "dcmtk/ofstd/ofconapp.h"
+
+#ifdef WITH_ZLIB
+#include "itk_zlib.h"                     /* for zlibVersion() */
+#endif
+#ifdef DCMTK_ENABLE_CHARSET_CONVERSION
+#include "dcmtk/ofstd/ofchrenc.h"     /* for OFCharacterEncoding */
+#endif
+
+#define OFFIS_CONSOLE_APPLICATION "dsr2html"
+
+static OFLogger dsr2htmlLogger = OFLog::getLogger("dcmtk.apps." OFFIS_CONSOLE_APPLICATION);
+
+static char rcsid[] = "$dcmtk: " OFFIS_CONSOLE_APPLICATION " v"
+  OFFIS_DCMTK_VERSION " " OFFIS_DCMTK_RELEASEDATE " $";
+
+
+// ********************************************
+
+
+static OFCondition renderFile(STD_NAMESPACE ostream &out,
+                              const char *ifname,
+                              const char *cssName,
+                              const char *defaultCharset,
+                              const E_FileReadMode readMode,
+                              const E_TransferSyntax xfer,
+                              const size_t readFlags,
+                              const size_t renderFlags,
+                              const OFBool checkAllStrings,
+                              const OFBool convertToUTF8)
+{
+    OFCondition result = EC_Normal;
+
+    if ((ifname == NULL) || (strlen(ifname) == 0))
+    {
+        OFLOG_FATAL(dsr2htmlLogger, OFFIS_CONSOLE_APPLICATION << ": invalid filename: <empty string>");
+        return EC_IllegalParameter;
+    }
+
+    DcmFileFormat *dfile = new DcmFileFormat();
+    if (dfile != NULL)
+    {
+        if (readMode == ERM_dataset)
+            result = dfile->getDataset()->loadFile(ifname, xfer);
+        else
+            result = dfile->loadFile(ifname, xfer);
+        if (result.bad())
+        {
+            OFLOG_FATAL(dsr2htmlLogger, OFFIS_CONSOLE_APPLICATION << ": error (" << result.text()
+                << ") reading file: " << ifname);
+        }
+    } else
+        result = EC_MemoryExhausted;
+
+#ifdef DCMTK_ENABLE_CHARSET_CONVERSION
+    /* convert all DICOM strings to UTF-8 (if requested) */
+    if (result.good() && convertToUTF8)
+    {
+        DcmDataset *dset = dfile->getDataset();
+        OFLOG_INFO(dsr2htmlLogger, "converting all element values that are affected by SpecificCharacterSet (0008,0005) to UTF-8");
+        // check whether SpecificCharacterSet is absent but needed
+        if ((defaultCharset != NULL) && !dset->tagExistsWithValue(DCM_SpecificCharacterSet) &&
+            dset->containsExtendedCharacters(OFFalse /*checkAllStrings*/))
+        {
+            // use the manually specified source character set
+            result = dset->convertCharacterSet(defaultCharset, OFString("ISO_IR 192"));
+        } else {
+            // expect that SpecificCharacterSet contains the correct value
+            result = dset->convertToUTF8();
+        }
+        if (result.bad())
+        {
+            OFLOG_FATAL(dsr2htmlLogger, result.text() << ": converting file to UTF-8: " << ifname);
+        }
+    }
+#else
+    // avoid compiler warning on unused variable
+    (void)convertToUTF8;
+#endif
+    if (result.good())
+    {
+        result = EC_CorruptedData;
+        DcmDataset *dset = dfile->getDataset();
+        DSRDocument *dsrdoc = new DSRDocument();
+        if (dsrdoc != NULL)
+        {
+            result = dsrdoc->read(*dset, readFlags);
+            if (result.good())
+            {
+                // check extended character set
+                OFString charset;
+                if ((dsrdoc->getSpecificCharacterSet(charset).bad() || charset.empty()) &&
+                    dset->containsExtendedCharacters(checkAllStrings))
+                {
+                    // we have an unspecified extended character set
+                    if (defaultCharset == NULL)
+                    {
+                        // the dataset contains non-ASCII characters that really should not be there
+                        OFLOG_FATAL(dsr2htmlLogger, OFFIS_CONSOLE_APPLICATION << ": SpecificCharacterSet (0008,0005) "
+                            << "element absent but extended characters used in file: " << ifname);
+                        OFLOG_DEBUG(dsr2htmlLogger, "use option --charset-assume to manually specify an appropriate character set");
+                        result = EC_IllegalCall;
+                    } else {
+                        // use the default character set specified by the user
+                        result = dsrdoc->setSpecificCharacterSet(defaultCharset);
+                        if (dsrdoc->getSpecificCharacterSetType() == DSRTypes::CS_unknown)
+                        {
+                            OFLOG_FATAL(dsr2htmlLogger, OFFIS_CONSOLE_APPLICATION << ": Character set '"
+                                << defaultCharset << "' specified with option --charset-assume not supported");
+                            result = EC_IllegalCall;
+                        }
+                        else if (result.bad())
+                        {
+                            OFLOG_FATAL(dsr2htmlLogger, OFFIS_CONSOLE_APPLICATION << ": Cannot use character set '"
+                                << defaultCharset << "' specified with option --charset-assume: " << result.text());
+                        }
+                    }
+                }
+                if (result.good())
+                    result = dsrdoc->renderHTML(out, renderFlags, cssName);
+            } else {
+                OFLOG_FATAL(dsr2htmlLogger, OFFIS_CONSOLE_APPLICATION << ": error (" << result.text()
+                    << ") parsing file: " << ifname);
+            }
+        }
+        delete dsrdoc;
+    }
+    delete dfile;
+
+    return result;
+}
+
+
+#define SHORTCOL 3
+#define LONGCOL 22
+
+
+int main(int argc, char *argv[])
+{
+    size_t opt_readFlags = 0;
+    size_t opt_renderFlags = DSRTypes::HF_renderDcmtkFootnote;
+    const char *opt_cssName = NULL;
+    const char *opt_defaultCharset = NULL;
+    E_FileReadMode opt_readMode = ERM_autoDetect;
+    E_TransferSyntax opt_ixfer = EXS_Unknown;
+    OFBool opt_checkAllStrings = OFFalse;
+    OFBool opt_convertToUTF8 = OFFalse;
+
+    OFConsoleApplication app(OFFIS_CONSOLE_APPLICATION, "Render DICOM SR file and data set to HTML/XHTML", rcsid);
+    OFCommandLine cmd;
+    cmd.setOptionColumns(LONGCOL, SHORTCOL);
+    cmd.setParamColumn(LONGCOL + SHORTCOL + 4);
+
+    cmd.addParam("dsrfile-in",   "DICOM SR input filename to be rendered", OFCmdParam::PM_Mandatory);
+    cmd.addParam("htmlfile-out", "HTML/XHTML output filename (default: stdout)", OFCmdParam::PM_Optional);
+
+    cmd.addGroup("general options:", LONGCOL, SHORTCOL + 2);
+      cmd.addOption("--help",                   "-h",     "print this help text and exit", OFCommandLine::AF_Exclusive);
+      cmd.addOption("--version",                          "print version information and exit", OFCommandLine::AF_Exclusive);
+      OFLog::addOptions(cmd);
+
+    cmd.addGroup("input options:");
+      cmd.addSubGroup("input file format:");
+        cmd.addOption("--read-file",            "+f",     "read file format or data set (default)");
+        cmd.addOption("--read-file-only",       "+fo",    "read file format only");
+        cmd.addOption("--read-dataset",         "-f",     "read data set without file meta information");
+      cmd.addSubGroup("input transfer syntax:");
+        cmd.addOption("--read-xfer-auto",       "-t=",    "use TS recognition (default)");
+        cmd.addOption("--read-xfer-detect",     "-td",    "ignore TS specified in the file meta header");
+        cmd.addOption("--read-xfer-little",     "-te",    "read with explicit VR little endian TS");
+        cmd.addOption("--read-xfer-big",        "-tb",    "read with explicit VR big endian TS");
+        cmd.addOption("--read-xfer-implicit",   "-ti",    "read with implicit VR little endian TS");
+
+    cmd.addGroup("processing options:");
+      cmd.addSubGroup("additional information:");
+        cmd.addOption("--processing-details",   "-Ip",    "show currently processed content item");
+      cmd.addSubGroup("error handling:");
+        cmd.addOption("--unknown-relationship", "-Er",    "accept unknown/missing relationship type");
+        cmd.addOption("--invalid-item-value",   "-Ev",    "accept invalid content item value\n(e.g. violation of VR or VM definition)");
+        cmd.addOption("--ignore-constraints",   "-Ec",    "ignore relationship content constraints");
+        cmd.addOption("--ignore-item-errors",   "-Ee",    "do not abort on content item errors, just warn\n(e.g. missing value type specific attributes)");
+        cmd.addOption("--skip-invalid-items",   "-Ei",    "skip invalid content items (incl. sub-tree)");
+        cmd.addOption("--disable-vr-checker",   "-Dv",    "disable check for VR-conformant string values");
+      cmd.addSubGroup("character set:");
+        cmd.addOption("--charset-require",      "+Cr",    "require declaration of ext. charset (default)");
+        cmd.addOption("--charset-assume",       "+Ca", 1, "[c]harset: string",
+                                                          "assume charset c if no extended charset declared");
+        cmd.addOption("--charset-check-all",              "check all data elements with string values\n(default: only PN, LO, LT, SH, ST, UC and UT)");
+#ifdef DCMTK_ENABLE_CHARSET_CONVERSION
+        cmd.addOption("--convert-to-utf8",      "+U8",    "convert all element values that are affected\nby Specific Character Set (0008,0005) to UTF-8");
+#endif
+    cmd.addGroup("output options:");
+      cmd.addSubGroup("HTML/XHTML compatibility:");
+        cmd.addOption("--html-3.2",             "+H3",    "use only HTML version 3.2 compatible features");
+        cmd.addOption("--html-4.0",             "+H4",    "allow all HTML version 4.01 features (default)");
+        cmd.addOption("--xhtml-1.1",            "+X1",    "comply with XHTML version 1.1 specification");
+        cmd.addOption("--add-document-type",    "+Hd",    "add reference to SGML document type definition");
+      cmd.addSubGroup("cascading style sheet (CSS), not with HTML 3.2:");
+        cmd.addOption("--css-reference",        "+Sr", 1, "URL: string",
+                                                          "add reference to specified CSS to document");
+        cmd.addOption("--css-file",             "+Sf", 1, "[f]ilename: string",
+                                                          "embed content of specified CSS into document");
+      cmd.addSubGroup("general rendering:");
+        cmd.addOption("--expand-inline",        "+Ri",    "expand short content items inline (default)");
+        cmd.addOption("--never-expand-inline",  "-Ri",    "never expand content items inline");
+        cmd.addOption("--always-expand-inline", "+Ra",    "always expand content items inline");
+        cmd.addOption("--render-full-data",     "+Rd",    "render full data of content items");
+        cmd.addOption("--section-title-inline", "+Rt",    "render section titles inline, not separately");
+      cmd.addSubGroup("document rendering:");
+        cmd.addOption("--document-type-title",  "+Dt",    "use document type as document title (default)");
+        cmd.addOption("--patient-info-title",   "+Dp",    "use patient information as document title");
+        cmd.addOption("--no-document-header",   "-Dh",    "do not render general document information");
+      cmd.addSubGroup("code rendering:");
+        cmd.addOption("--render-inline-codes",  "+Ci",    "render codes in continuous text blocks");
+        cmd.addOption("--concept-name-codes",   "+Cn",    "render code of concept names");
+        cmd.addOption("--numeric-unit-codes",   "+Cu",    "render code of numeric measurement units");
+        cmd.addOption("--code-value-unit",      "+Cv",    "use code value as measurement unit (default)");
+        cmd.addOption("--code-meaning-unit",    "+Cm",    "use code meaning as measurement unit");
+        cmd.addOption("--render-all-codes",     "+Cc",    "render all codes (implies +Ci, +Cn and +Cu)");
+        cmd.addOption("--code-details-tooltip", "+Ct",    "render code details as a tooltip (implies +Cc)");
+
+    /* evaluate command line */
+    prepareCmdLineArgs(argc, argv, OFFIS_CONSOLE_APPLICATION);
+    if (app.parseCommandLine(cmd, argc, argv))
+    {
+        /* check exclusive options first */
+        if (cmd.hasExclusiveOption())
+        {
+            if (cmd.findOption("--version"))
+            {
+                app.printHeader(OFTrue /*print host identifier*/);
+                COUT << OFendl << "External libraries used:";
+#if !defined(WITH_ZLIB) && !defined(DCMTK_ENABLE_CHARSET_CONVERSION)
+                COUT << " none" << OFendl;
+#else
+                COUT << OFendl;
+#endif
+#ifdef WITH_ZLIB
+                COUT << "- ZLIB, Version " << zlibVersion() << OFendl;
+#endif
+#ifdef DCMTK_ENABLE_CHARSET_CONVERSION
+                COUT << "- " << OFCharacterEncoding::getLibraryVersionString() << OFendl;
+#endif
+                return 0;
+            }
+        }
+
+        /* general options */
+
+        OFLog::configureFromCommandLine(cmd, app);
+
+        /* input options */
+
+        cmd.beginOptionBlock();
+        if (cmd.findOption("--read-file")) opt_readMode = ERM_autoDetect;
+        if (cmd.findOption("--read-file-only")) opt_readMode = ERM_fileOnly;
+        if (cmd.findOption("--read-dataset")) opt_readMode = ERM_dataset;
+        cmd.endOptionBlock();
+
+        cmd.beginOptionBlock();
+        if (cmd.findOption("--read-xfer-auto"))
+            opt_ixfer = EXS_Unknown;
+        if (cmd.findOption("--read-xfer-detect"))
+            dcmAutoDetectDatasetXfer.set(OFTrue);
+        if (cmd.findOption("--read-xfer-little"))
+        {
+            app.checkDependence("--read-xfer-little", "--read-dataset", opt_readMode == ERM_dataset);
+            opt_ixfer = EXS_LittleEndianExplicit;
+        }
+        if (cmd.findOption("--read-xfer-big"))
+        {
+            app.checkDependence("--read-xfer-big", "--read-dataset", opt_readMode == ERM_dataset);
+            opt_ixfer = EXS_BigEndianExplicit;
+        }
+        if (cmd.findOption("--read-xfer-implicit"))
+        {
+            app.checkDependence("--read-xfer-implicit", "--read-dataset", opt_readMode == ERM_dataset);
+            opt_ixfer = EXS_LittleEndianImplicit;
+        }
+        cmd.endOptionBlock();
+
+        /* processing options */
+
+        if (cmd.findOption("--processing-details"))
+        {
+            app.checkDependence("--processing-details", "verbose mode", dsr2htmlLogger.isEnabledFor(OFLogger::INFO_LOG_LEVEL));
+            opt_readFlags |= DSRTypes::RF_showCurrentlyProcessedItem;
+        }
+        if (cmd.findOption("--unknown-relationship"))
+            opt_readFlags |= DSRTypes::RF_acceptUnknownRelationshipType;
+        if (cmd.findOption("--invalid-item-value"))
+            opt_readFlags |= DSRTypes::RF_acceptInvalidContentItemValue;
+        if (cmd.findOption("--ignore-constraints"))
+            opt_readFlags |= DSRTypes::RF_ignoreRelationshipConstraints;
+        if (cmd.findOption("--ignore-item-errors"))
+            opt_readFlags |= DSRTypes::RF_ignoreContentItemErrors;
+        if (cmd.findOption("--skip-invalid-items"))
+            opt_readFlags |= DSRTypes::RF_skipInvalidContentItems;
+        if (cmd.findOption("--disable-vr-checker"))
+            dcmEnableVRCheckerForStringValues.set(OFFalse);
+
+        /* character set options */
+        cmd.beginOptionBlock();
+        if (cmd.findOption("--charset-require"))
+           opt_defaultCharset = NULL;
+        if (cmd.findOption("--charset-assume"))
+          app.checkValue(cmd.getValue(opt_defaultCharset));
+        cmd.endOptionBlock();
+        if (cmd.findOption("--charset-check-all"))
+            opt_checkAllStrings = OFTrue;
+#ifdef DCMTK_ENABLE_CHARSET_CONVERSION
+        if (cmd.findOption("--convert-to-utf8"))
+            opt_convertToUTF8 = OFTrue;
+#endif
+
+        /* output options */
+
+        /* HTML compatibility */
+        cmd.beginOptionBlock();
+        if (cmd.findOption("--html-3.2"))
+            opt_renderFlags = (opt_renderFlags & ~DSRTypes::HF_XHTML11Compatibility) | DSRTypes::HF_HTML32Compatibility;
+        if (cmd.findOption("--html-4.0"))
+            opt_renderFlags = (opt_renderFlags & ~(DSRTypes::HF_XHTML11Compatibility | DSRTypes::HF_HTML32Compatibility));
+        if (cmd.findOption("--xhtml-1.1"))
+            opt_renderFlags = (opt_renderFlags & ~DSRTypes::HF_HTML32Compatibility) | DSRTypes::HF_XHTML11Compatibility | DSRTypes::HF_addDocumentTypeReference;
+        cmd.endOptionBlock();
+
+        if (cmd.findOption("--add-document-type"))
+            opt_renderFlags |= DSRTypes::HF_addDocumentTypeReference;
+
+        /* cascading style sheet */
+        cmd.beginOptionBlock();
+        if (cmd.findOption("--css-reference"))
+        {
+            app.checkConflict("--css-reference", "--html-3.2", (opt_renderFlags & DSRTypes::HF_HTML32Compatibility) > 0);
+            opt_renderFlags &= ~DSRTypes::HF_copyStyleSheetContent;
+            app.checkValue(cmd.getValue(opt_cssName));
+        }
+        if (cmd.findOption("--css-file"))
+        {
+            app.checkConflict("--css-file", "--html-3.2", (opt_renderFlags & DSRTypes::HF_HTML32Compatibility) > 0);
+            opt_renderFlags |= DSRTypes::HF_copyStyleSheetContent;
+            app.checkValue(cmd.getValue(opt_cssName));
+        }
+        cmd.endOptionBlock();
+
+        /* general rendering */
+        cmd.beginOptionBlock();
+        if (cmd.findOption("--expand-inline"))
+        {
+            /* default */
+        }
+        if (cmd.findOption("--never-expand-inline"))
+            opt_renderFlags |= DSRTypes::HF_neverExpandChildrenInline;
+        if (cmd.findOption("--always-expand-inline"))
+            opt_renderFlags |= DSRTypes::HF_alwaysExpandChildrenInline;
+        cmd.endOptionBlock();
+
+        if (cmd.findOption("--render-full-data"))
+            opt_renderFlags |= DSRTypes::HF_renderFullData;
+
+        if (cmd.findOption("--section-title-inline"))
+            opt_renderFlags |= DSRTypes::HF_renderSectionTitlesInline;
+
+        /* document rendering */
+        cmd.beginOptionBlock();
+        if (cmd.findOption("--document-type-title"))
+        {
+            /* default */
+        }
+        if (cmd.findOption("--patient-info-title"))
+            opt_renderFlags |= DSRTypes::HF_renderPatientTitle;
+        cmd.endOptionBlock();
+
+        if (cmd.findOption("--no-document-header"))
+            opt_renderFlags |= DSRTypes::HF_renderNoDocumentHeader;
+
+        /* code rendering */
+        if (cmd.findOption("--render-inline-codes"))
+            opt_renderFlags |= DSRTypes::HF_renderInlineCodes;
+        if (cmd.findOption("--concept-name-codes"))
+            opt_renderFlags |= DSRTypes::HF_renderConceptNameCodes;
+        if (cmd.findOption("--numeric-unit-codes"))
+            opt_renderFlags |= DSRTypes::HF_renderNumericUnitCodes;
+        if (cmd.findOption("--code-value-unit"))
+            opt_renderFlags &= ~DSRTypes::HF_useCodeMeaningAsUnit;
+        if (cmd.findOption("--code-meaning-unit"))
+            opt_renderFlags |= DSRTypes::HF_useCodeMeaningAsUnit;
+        if (cmd.findOption("--render-all-codes"))
+            opt_renderFlags |= DSRTypes::HF_renderAllCodes;
+        if (cmd.findOption("--code-details-tooltip"))
+        {
+            app.checkConflict("--code-details-tooltip", "--html-3.2", (opt_renderFlags & DSRTypes::HF_HTML32Compatibility) > 0);
+            opt_renderFlags |= DSRTypes::HF_useCodeDetailsTooltip;
+        }
+    }
+
+    /* print resource identifier */
+    OFLOG_DEBUG(dsr2htmlLogger, rcsid << OFendl);
+
+    /* make sure data dictionary is loaded */
+    if (!dcmDataDict.isDictionaryLoaded())
+    {
+        OFLOG_WARN(dsr2htmlLogger, "no data dictionary loaded, check environment variable: "
+            << DCM_DICT_ENVIRONMENT_VARIABLE);
+    }
+
+    // map "old" charset names to DICOM defined terms
+    if (opt_defaultCharset != NULL)
+    {
+        OFString charset(opt_defaultCharset);
+        if (charset == "latin-1")
+            opt_defaultCharset = "ISO_IR 100";
+        else if (charset == "latin-2")
+            opt_defaultCharset = "ISO_IR 101";
+        else if (charset == "latin-3")
+            opt_defaultCharset = "ISO_IR 109";
+        else if (charset == "latin-4")
+            opt_defaultCharset = "ISO_IR 110";
+        else if (charset == "latin-5")
+            opt_defaultCharset = "ISO_IR 148";
+        else if (charset == "cyrillic")
+            opt_defaultCharset = "ISO_IR 144";
+        else if (charset == "arabic")
+            opt_defaultCharset = "ISO_IR 127";
+        else if (charset == "greek")
+            opt_defaultCharset = "ISO_IR 126";
+        else if (charset == "hebrew")
+            opt_defaultCharset = "ISO_IR 138";
+    }
+
+    int result = 0;
+    const char *ifname = NULL;
+    /* first parameter is treated as the input filename */
+    cmd.getParam(1, ifname);
+    if (cmd.getParamCount() == 2)
+    {
+        /* second parameter specifies the output filename */
+        const char *ofname = NULL;
+        cmd.getParam(2, ofname);
+        STD_NAMESPACE ofstream stream(ofname);
+        if (stream.good())
+        {
+            if (renderFile(stream, ifname, opt_cssName, opt_defaultCharset, opt_readMode, opt_ixfer, opt_readFlags,
+                opt_renderFlags, opt_checkAllStrings, opt_convertToUTF8).bad())
+            {
+                result = 2;
+            }
+        } else
+            result = 1;
+    } else {
+        /* use standard output */
+        if (renderFile(COUT, ifname, opt_cssName, opt_defaultCharset, opt_readMode, opt_ixfer, opt_readFlags,
+            opt_renderFlags, opt_checkAllStrings, opt_convertToUTF8).bad())
+        {
+            result = 3;
+        }
+    }
+
+    return result;
+}

--- a/src/io/internal/pipelines/dicom/structured-report-to-html.cxx
+++ b/src/io/internal/pipelines/dicom/structured-report-to-html.cxx
@@ -41,6 +41,10 @@
 
 #include "dcmtk/config/osconfig.h"    /* make sure OS specific configuration is included first */
 
+// Fix warning for redefinition of __STDC_FORMAT_MACROS in the header include tree for dsrdoc.h
+#ifdef __STDC_FORMAT_MACROS
+  #undef __STDC_FORMAT_MACROS
+#endif
 #include "dcmtk/dcmsr/dsrdoc.h"       /* for main interface class DSRDocument */
 
 #include "dcmtk/dcmdata/dctk.h"       /* for typical set of "dcmdata" headers */

--- a/src/itk-wasm-cli.js
+++ b/src/itk-wasm-cli.js
@@ -208,11 +208,20 @@ function run(wasmBinary, options) {
   }
 }
 
-
-function camelCase(kebobCase) {
-  return kebobCase.replace(/-([a-z])/g, (kk) => {
+function camelCase(param) {
+  // make any alphabets that follows '-' an uppercase character, and remove the corresponding hyphen
+  let cameledParam = param.replace(/-([a-z])/g, (kk) => {
     return kk[1].toUpperCase();
   });
+
+  // remove all non-alphanumeric characters
+  const outParam = cameledParam.replace(/([^0-9a-z])/ig, '')
+
+  // check if resulting string is empty
+  if(outParam === '') {
+    console.error(`Resulting string is empty.`)
+  }
+  return outParam
 }
 
 const interfaceJsonTypeToTypeScriptType = new Map([


### PR DESCRIPTION
Add capability to read and render a dicom file structured report into an html document using implementation from DCMTK's `dsr2html` command line app.