### PR TITLE
fix(SR-test-data): switch to file-level CID values

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -37,5 +37,5 @@ export { default as WorkerPoolFunction } from './WorkerPoolFunction.js'
 export { default as WorkerPoolProgressCallback } from './WorkerPoolProgressCallback.js'
 export { default as WorkerPoolRunTasksResult } from './WorkerPoolRunTasksResult.js'
 
-const version = '1.0.0-b.18';
-export { version };
+const version = '1.0.0-b.18'
+export { version }

--- a/src/core/internal/camelCase.ts
+++ b/src/core/internal/camelCase.ts
@@ -1,15 +1,15 @@
 function camelCase (kebobCase: string): string {
   // make any alphabets that follows '-' an uppercase character, and remove the corresponding hyphen
-  let cameledParam = kebobCase.replace(/-([a-z])/g, (kk) => {
-    return kk[1].toUpperCase();
-  });
+  const cameledParam = kebobCase.replace(/-([a-z])/g, (kk) => {
+    return kk[1].toUpperCase()
+  })
 
   // remove all non-alphanumeric characters
   const outParam = cameledParam.replace(/([^0-9a-z])/ig, '')
 
   // check if resulting string is empty
-  if(outParam === '') {
-    console.error(`Resulting string is empty.`)
+  if (outParam === '') {
+    console.error('Resulting string is empty.')
   }
   return outParam
 }

--- a/test/Input/104.1-SR-printed-to-pdf.dcm.cid
+++ b/test/Input/104.1-SR-printed-to-pdf.dcm.cid
@@ -1,1 +1,1 @@
-bafybeicotyose3ijwdrfg756zywr3swu6r37672z55iuofnavmbr2k65gi
+bafkreig3blddcxtvuv4a7qjtvvfrcgm5ubskm7ik3mlopnyzyoncasrgyq

--- a/test/Input/88.67-radiation-dose-SR.dcm.cid
+++ b/test/Input/88.67-radiation-dose-SR.dcm.cid
@@ -1,1 +1,1 @@
-bafybeidg3iito3z6dtpgwfuufgj4cgm2pte6f6gdbcvwlzs5fq35okzz4i
+bafkreicdondblix2h5meriyvrqvrtdkxmxpbsqjlgm6s2psz53l435zvsu


### PR DESCRIPTION
By default web3.storage provides CID value that points to a wrapped
parent folder. This leads to corrupt file download.
Fix is to extract the correct file-level CID from the download URL.

For more details see:
https://web3.storage/docs/how-tos/troubleshooting/#the-cid-returned-when-uploading-doesnt-link-directly-to-my-file


Additional updates regarding style fixes by linter.