### PR TITLE
fix(itkConfig.ts): Import from './browser/index.js'

### DIFF
--- a/src/itkConfig.ts
+++ b/src/itkConfig.ts
@@ -1,4 +1,4 @@
-import { version } from './index.js'
+import { version } from './browser/index.js'
 
 const itkConfig = {
   webWorkersUrl: undefined,


### PR DESCRIPTION
Otherwise, this ends up loading './index.js', which brings in Node.js, which causes issues for Vite / Rollup when bundling for the browser.

Closes #654