### PR TITLE
feat(key-object-selection): support for rendering key object selection structured report

### DIFF
--- a/dist/dicom/src/StructuredReportToHtmlOptions.ts
+++ b/dist/dicom/src/StructuredReportToHtmlOptions.ts
@@ -57,6 +57,9 @@ interface StructuredReportToHtmlOptions {
 by Specific Character Set (0008,0005) to UTF-8 */
   convertToUtf8?: boolean
 
+  /** URL: string. Append specificed URL prefix to hyperlinks of referenced composite objects in the document. */
+  urlPrefix?: string
+
   /** use only HTML version 3.2 compatible features */
   html32?: boolean
 

--- a/dist/dicom/src/readDicomEncapsulatedPdf.ts
+++ b/dist/dicom/src/readDicomEncapsulatedPdf.ts
@@ -1,6 +1,7 @@
 import {
   BinaryStream,
   InterfaceTypes,
+  PipelineInput,
   runPipeline
 } from 'itk-wasm'
 
@@ -23,7 +24,7 @@ async function readDicomEncapsulatedPdf(
   const desiredOutputs = [
     { type: InterfaceTypes.BinaryStream },
   ]
-  const inputs = [
+  const inputs: [ PipelineInput ] = [
     { type: InterfaceTypes.BinaryFile, data: { data: dicomFile, path: "file0" }  },
   ]
 

--- a/dist/dicom/src/readDicomEncapsulatedPdfNode.ts
+++ b/dist/dicom/src/readDicomEncapsulatedPdfNode.ts
@@ -1,6 +1,7 @@
 import {
   BinaryStream,
   InterfaceTypes,
+  PipelineInput,
   runPipelineNode
 } from 'itk-wasm'
 
@@ -24,7 +25,7 @@ async function readDicomEncapsulatedPdfNode(  dicomFile: Uint8Array,
   const desiredOutputs = [
     { type: InterfaceTypes.BinaryStream },
   ]
-  const inputs = [
+  const inputs: [ PipelineInput ] = [
     { type: InterfaceTypes.BinaryFile, data: { data: dicomFile, path: "file0" }  },
   ]
 

--- a/dist/dicom/src/structuredReportToHtml.ts
+++ b/dist/dicom/src/structuredReportToHtml.ts
@@ -1,6 +1,7 @@
 import {
   TextStream,
   InterfaceTypes,
+  PipelineInput,
   runPipeline
 } from 'itk-wasm'
 
@@ -23,7 +24,7 @@ async function structuredReportToHtml(
   const desiredOutputs = [
     { type: InterfaceTypes.TextStream },
   ]
-  const inputs = [
+  const inputs: [ PipelineInput ] = [
     { type: InterfaceTypes.BinaryFile, data: { data: dicomFile, path: "file0" }  },
   ]
 
@@ -80,13 +81,16 @@ async function structuredReportToHtml(
     args.push('--charset-require')
   }
   if (options.charsetAssume) {
-    args.push('--charset-assume', '1')
+    args.push('--charset-assume', options.charsetAssume.toString())
   }
   if (options.charsetCheckAll) {
     args.push('--charset-check-all')
   }
   if (options.convertToUtf8) {
     args.push('--convert-to-utf8')
+  }
+  if (options.urlPrefix) {
+    args.push('--url-prefix', options.urlPrefix.toString())
   }
   if (options.html32) {
     args.push('--html-3.2')
@@ -101,10 +105,14 @@ async function structuredReportToHtml(
     args.push('--add-document-type')
   }
   if (options.cssReference) {
-    args.push('--css-reference', '2')
+    const inputCountString = inputs.length.toString()
+    inputs.push({ type: InterfaceTypes.TextStream, data: { data: options.cssReference } })
+    args.push('--css-reference', inputCountString)
   }
   if (options.cssFile) {
-    args.push('--css-file', '3')
+    const inputFile = 'file' + inputs.length.toString()
+    inputs.push({ type: InterfaceTypes.TextFile, data: { data: options.cssFile, path: inputFile } })
+    args.push('--css-file', inputFile)
   }
   if (options.expandInline) {
     args.push('--expand-inline')

--- a/dist/dicom/src/structuredReportToHtmlNode.ts
+++ b/dist/dicom/src/structuredReportToHtmlNode.ts
@@ -1,6 +1,7 @@
 import {
   TextStream,
   InterfaceTypes,
+  PipelineInput,
   runPipelineNode
 } from 'itk-wasm'
 
@@ -24,7 +25,7 @@ async function structuredReportToHtmlNode(  dicomFile: Uint8Array,
   const desiredOutputs = [
     { type: InterfaceTypes.TextStream },
   ]
-  const inputs = [
+  const inputs: [ PipelineInput ] = [
     { type: InterfaceTypes.BinaryFile, data: { data: dicomFile, path: "file0" }  },
   ]
 
@@ -81,13 +82,16 @@ async function structuredReportToHtmlNode(  dicomFile: Uint8Array,
     args.push('--charset-require')
   }
   if (options.charsetAssume) {
-    args.push('--charset-assume', '1')
+    args.push('--charset-assume', options.charsetAssume.toString())
   }
   if (options.charsetCheckAll) {
     args.push('--charset-check-all')
   }
   if (options.convertToUtf8) {
     args.push('--convert-to-utf8')
+  }
+  if (options.urlPrefix) {
+    args.push('--url-prefix', options.urlPrefix.toString())
   }
   if (options.html32) {
     args.push('--html-3.2')
@@ -102,10 +106,14 @@ async function structuredReportToHtmlNode(  dicomFile: Uint8Array,
     args.push('--add-document-type')
   }
   if (options.cssReference) {
-    args.push('--css-reference', '2')
+    const inputCountString = inputs.length.toString()
+    inputs.push({ type: InterfaceTypes.TextStream, data: { data: options.cssReference } })
+    args.push('--css-reference', inputCountString)
   }
   if (options.cssFile) {
-    args.push('--css-file', '3')
+    const inputFile = 'file' + inputs.length.toString()
+    inputs.push({ type: InterfaceTypes.TextFile, data: { data: options.cssFile, path: inputFile } })
+    args.push('--css-file', inputFile)
   }
   if (options.expandInline) {
     args.push('--expand-inline')

--- a/dist/dicom/src/structuredReportToText.ts
+++ b/dist/dicom/src/structuredReportToText.ts
@@ -1,6 +1,7 @@
 import {
   TextStream,
   InterfaceTypes,
+  PipelineInput,
   runPipeline
 } from 'itk-wasm'
 
@@ -23,7 +24,7 @@ async function structuredReportToText(
   const desiredOutputs = [
     { type: InterfaceTypes.TextStream },
   ]
-  const inputs = [
+  const inputs: [ PipelineInput ] = [
     { type: InterfaceTypes.BinaryFile, data: { data: dicomFile, path: "file0" }  },
   ]
 

--- a/dist/dicom/src/structuredReportToTextNode.ts
+++ b/dist/dicom/src/structuredReportToTextNode.ts
@@ -1,6 +1,7 @@
 import {
   TextStream,
   InterfaceTypes,
+  PipelineInput,
   runPipelineNode
 } from 'itk-wasm'
 
@@ -24,7 +25,7 @@ async function structuredReportToTextNode(  dicomFile: Uint8Array,
   const desiredOutputs = [
     { type: InterfaceTypes.TextStream },
   ]
-  const inputs = [
+  const inputs: [ PipelineInput ] = [
     { type: InterfaceTypes.BinaryFile, data: { data: dicomFile, path: "file0" }  },
   ]
 

--- a/dist/dicom/test/node.js
+++ b/dist/dicom/test/node.js
@@ -70,3 +70,36 @@ test('readDicomEncapsulatedPdfNode', async t => {
   t.assert(outputBinaryStream != null)
   t.assert(outputBinaryStream.length === 91731)
 })
+
+test('read Key Object Selection SR', async t => {
+
+  const fileName = '88.59-KeyObjectSelection-SR.dcm'
+  const testFilePath = `../../build-emscripten/ExternalData/test/Input/${fileName}`
+  const dicomFileBuffer = fs.readFileSync(testFilePath)
+  const dicomFile = new Uint8Array(dicomFileBuffer)
+
+  const { outputText } = await structuredReportToHtmlNode(
+    dicomFile, {
+      urlPrefix: 'http://my-custom-dicom-server/dicom.cgi',
+      cssReference: "https://css-host/dir/subdir/my-first-style.css",
+    }
+  )
+
+  t.assert(outputText.includes('http://my-custom-dicom-server/dicom.cgi'))
+  t.assert(!outputText.includes('http://localhost/dicom.cgi'))
+  t.assert(outputText.includes(`<link rel="stylesheet" type="text/css" href="https://css-host/dir/subdir/my-first-style.css">`))
+
+  const cssfileName = 'test-style.css'
+  const testCssFilePath = `../../build-emscripten/ExternalData/test/Input/${cssfileName}`
+  const cssFileBuffer = fs.readFileSync(testCssFilePath)
+
+  const { outputText: outputWithCSSFile } = await structuredReportToHtmlNode(
+    dicomFile, { cssFile: cssFileBuffer })
+
+  t.assert(outputWithCSSFile.includes('<style type="text/css">'))
+  t.assert(outputWithCSSFile.includes('background-color: lightblue;'))
+  t.assert(outputWithCSSFile.includes('margin-left: 20px;'))
+  t.assert(outputWithCSSFile.includes('</style>'))
+  t.assert(!outputWithCSSFile.includes('http://my-custom-dicom-server/dicom.cgi'))
+  t.assert(outputWithCSSFile.includes('http://localhost/dicom.cgi'))
+})

--- a/src/docker/itk-wasm-base/Dockerfile
+++ b/src/docker/itk-wasm-base/Dockerfile
@@ -21,7 +21,7 @@ RUN git clone https://github.com/KitwareMedical/ITK.git && \
 RUN sed -i -e '/^set(DCMTK_GIT_REPOSITORY/c\set(DCMTK_GIT_REPOSITORY "https://github.com/InsightSoftwareConsortium/DCMTK.git")' \
     /ITK/Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake
 
-RUN sed -i -e '/^set(DCMTK_GIT_TAG/c\set(DCMTK_GIT_TAG "66fce6822afb16bcfd926ac8a5f4ed8d7cd10981")' \
+RUN sed -i -e '/^set(DCMTK_GIT_TAG/c\set(DCMTK_GIT_TAG "f9da0c6a79bac564cd5c102bb470c4524279d351")' \
     /ITK/Modules/ThirdParty/DCMTK/DCMTKGitTag.cmake
 
 ARG CMAKE_BUILD_TYPE=Release

--- a/src/io/internal/pipelines/dicom/structured-report-to-html.cxx
+++ b/src/io/internal/pipelines/dicom/structured-report-to-html.cxx
@@ -243,7 +243,7 @@ int main(int argc, char * argv[])
   bool charsetRequire{false};
   pipeline.add_flag("--charset-require", charsetRequire,    "require declaration of ext. charset (default)");
   std::string charsetAssumeValue;
-  pipeline.add_option("--charset-assume", charsetAssumeValue, "[c]harset: string, assume charset c if no extended charset declared")->type_name("INPUT_TEXT_STREAM");
+  pipeline.add_option("--charset-assume", charsetAssumeValue, "[c]harset: string, assume charset c if no extended charset declared");
   bool charsetCheckAll{false};
   pipeline.add_flag("--charset-check-all", charsetCheckAll, "check all data elements with string values\n(default: only PN, LO, LT, SH, ST, UC and UT)");
 #ifdef DCMTK_ENABLE_CHARSET_CONVERSION

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,8 +50,10 @@ ExternalData_Expand_Arguments(
   DATA{Input/PNGSeries/,REGEX:mri3D_.[0-9]+.png}
   DATA{Input/11706c2.CNG.swc}
   DATA{Input/88.33-comprehensive-SR.dcm}
+  DATA{Input/88.59-KeyObjectSelection-SR.dcm}
   DATA{Input/88.67-radiation-dose-SR.dcm}
   DATA{Input/104.1-SR-printed-to-pdf.dcm}
+  DATA{Input/test-style.css}
 
   DATA{Baseline/web_worker_pool.cy.png}
   )

--- a/test/Input/88.59-KeyObjectSelection-SR.dcm.cid
+++ b/test/Input/88.59-KeyObjectSelection-SR.dcm.cid
@@ -1,0 +1,1 @@
+bafkreieghxtlnscrkh3zjd22be7gtca6mz5tlnjzxm34ccwpgkstnisxom

--- a/test/Input/test-style.css.cid
+++ b/test/Input/test-style.css.cid
@@ -1,0 +1,1 @@
+bafkreif5iyhrvm5r6utc4b6y63xyxpc6jqqtcsiij5womcv2mndyk7lewy


### PR DESCRIPTION
Key object selection (KOS) structured report (SR) is similar to any other type of structured reports like radiation dose or comprehensive SR, except that a KOS has a list of referenced composite objects (images, waveforms, etc). These references are presented as a list of hyperlinks to the DICOM database files.

DCMTK renders these hyperlinks using a fixed literal ` http://localhost/dicom.cgi ` which is hard coded through a:
```c++
#define HTML_HYPERLINK_PREFIX_FOR_CGI
```
We replace this with a passed string argument to allow flexible hyperlinks based on the requirements of the calling application.