### PR TITLE
ci(update-versions): Run during verifyReleaseCmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
       [
         "@semantic-release/exec",
         {
-          "prepareCmd": "node ./update-versions.cjs ${nextRelease.version}"
+          "verifyReleaseCmd": "node ./update-versions.cjs ${nextRelease.version}"
         }
       ],
       [


### PR DESCRIPTION
According to:

  https://github.com/semantic-release/semantic-release/blob/master/docs/extending/plugins-list.md

The npm tarball is generated by the @semantic-release/npm plugin during the `prepare` step. So, bump the update version script execution to the `verifyReleaseCmd`.