### PR TITLE
fix: Run update-versions during prepublishOnly npm step

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itk-wasm",
-  "version": "1.0.0-b.18",
+  "version": "0.0.0-semantically-released",
   "description": "High-performance spatial analysis in a web browser, Node.js, and reproducible execution across programming languages and hardware architectures.",
   "main": "./dist/index.js",
   "browser": {
@@ -56,7 +56,7 @@
     "test:chrome": "start-server-and-test start http-get://localhost:8083 cypress:runChrome",
     "test:firefox:ci": "start-server-and-test start http-get://localhost:8083 cypress:runFirefox:ci",
     "test:firefox": "start-server-and-test start http-get://localhost:8083 cypress:runFirefox",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build:tsc && node ./src/update-versions.cjs && npm run build:workerBundles && npm run build:workerMinBundles && npm run build:webpack"
   },
   "config": {
     "commitizen": {
@@ -175,12 +175,6 @@
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
-      [
-        "@semantic-release/exec",
-        {
-          "verifyReleaseCmd": "node ./update-versions.cjs ${nextRelease.version}"
-        }
-      ],
       [
         "@semantic-release/changelog",
         {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -37,5 +37,5 @@ export { default as WorkerPoolFunction } from './WorkerPoolFunction.js'
 export { default as WorkerPoolProgressCallback } from './WorkerPoolProgressCallback.js'
 export { default as WorkerPoolRunTasksResult } from './WorkerPoolRunTasksResult.js'
 
-const version = '1.0.0-b.18'
+const version = '0.0.0-semantically-released'
 export { version }

--- a/src/itkConfigDevelopment.ts
+++ b/src/itkConfigDevelopment.ts
@@ -1,4 +1,4 @@
-const version = '1.0.0-b.18'
+const version = '0.0.0-semantically-released'
 
 const itkConfig = {
   webWorkersUrl: undefined,

--- a/src/update-versions.cjs
+++ b/src/update-versions.cjs
@@ -1,9 +1,10 @@
 const fs = require('fs')
 
-const version = process.argv[2]
+let version = process.argv[2]
 if (!version) {
-  console.error(`usage: ${__filename} VERSION`)
-  process.exit(1)
+  const packageString = fs.readFileSync('package.json', { encoding: 'utf-8' })
+  const packageData = JSON.parse(packageString)
+  version = packageData.version
 }
 
 function rewriteVersion(filename) {


### PR DESCRIPTION
Get the version from package.json, which should be set by semantic-release.