### PR TITLE
fix(io-packages): Update with main package semantic-release version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "test:chrome": "start-server-and-test start http-get://localhost:8083 cypress:runChrome",
     "test:firefox:ci": "start-server-and-test start http-get://localhost:8083 cypress:runFirefox:ci",
     "test:firefox": "start-server-and-test start http-get://localhost:8083 cypress:runFirefox",
-    "prepublishOnly": "npm run build:tsc && node ./src/update-versions.cjs && npm run build:workerBundles && npm run build:workerMinBundles && npm run build:webpack"
+    "prepublishOnly": "npm run build:tsc && node ./src/update-versions.cjs && node ./src/io/internal/packages/package-json-gen.cjs && npm run build:workerBundles && npm run build:workerMinBundles && npm run build:webpack"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
The dependency on itk-wasm was `itk-wasm@0.0.0-semantically-released` following #668