### PR TITLE
fix(createWebWorkerPromise): Move up one directory

### DIFF
--- a/src/core/createWebWorkerPromise.ts
+++ b/src/core/createWebWorkerPromise.ts
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import WebworkerPromise from 'webworker-promise'
 
-import config from '../../itkConfig.js'
+import config from '../itkConfig.js'
 
 interface createWebWorkerPromiseResult {
   webworkerPromise: typeof WebworkerPromise
@@ -52,7 +52,7 @@ async function createWebWorkerPromise (existingWorker: Worker | null): Promise<c
     // importScripts / UMD is required over dynamic ESM import until Firefox
     // adds worker dynamic import support:
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1540913
-    worker = new Worker(new URL('../../web-workers/pipeline.worker.js', import.meta.url))
+    worker = new Worker(new URL('../web-workers/pipeline.worker.js', import.meta.url))
   } else {
     const pipelineWorkerUrl = config.pipelineWorkerUrl
     if (pipelineWorkerUrl.startsWith('http')) {

--- a/src/io/meshToPolyData.ts
+++ b/src/io/meshToPolyData.ts
@@ -1,4 +1,4 @@
-import createWebWorkerPromise from '../core/internal/createWebWorkerPromise.js'
+import createWebWorkerPromise from '../core/createWebWorkerPromise.js'
 import Mesh from '../core/Mesh.js'
 import InterfaceTypes from '../core/InterfaceTypes.js'
 import PolyData from '../core/PolyData.js'

--- a/src/io/polyDataToMesh.ts
+++ b/src/io/polyDataToMesh.ts
@@ -1,4 +1,4 @@
-import createWebWorkerPromise from '../core/internal/createWebWorkerPromise.js'
+import createWebWorkerPromise from '../core/createWebWorkerPromise.js'
 import Mesh from '../core/Mesh.js'
 import InterfaceTypes from '../core/InterfaceTypes.js'
 import PolyData from '../core/PolyData.js'

--- a/src/io/readDICOMTagsArrayBuffer.ts
+++ b/src/io/readDICOMTagsArrayBuffer.ts
@@ -1,4 +1,4 @@
-import createWebWorkerPromise from '../core/internal/createWebWorkerPromise.js'
+import createWebWorkerPromise from '../core/createWebWorkerPromise.js'
 import PipelineInput from '../pipeline/PipelineInput.js'
 import TextStream from '../core/TextStream.js'
 

--- a/src/io/readImageArrayBuffer.ts
+++ b/src/io/readImageArrayBuffer.ts
@@ -1,4 +1,4 @@
-import createWebWorkerPromise from '../core/internal/createWebWorkerPromise.js'
+import createWebWorkerPromise from '../core/createWebWorkerPromise.js'
 import Image from '../core/Image.js'
 import InterfaceTypes from '../core/InterfaceTypes.js'
 import PipelineInput from '../pipeline/PipelineInput.js'

--- a/src/io/readImageDICOMArrayBufferSeries.ts
+++ b/src/io/readImageDICOMArrayBufferSeries.ts
@@ -1,4 +1,4 @@
-import createWebWorkerPromise from '../core/internal/createWebWorkerPromise.js'
+import createWebWorkerPromise from '../core/createWebWorkerPromise.js'
 import WorkerPool from '../core/WorkerPool.js'
 import Metadata from '../core/Metadata.js'
 import stackImages from '../core/stackImages.js'

--- a/src/io/readMeshArrayBuffer.ts
+++ b/src/io/readMeshArrayBuffer.ts
@@ -1,4 +1,4 @@
-import createWebWorkerPromise from '../core/internal/createWebWorkerPromise.js'
+import createWebWorkerPromise from '../core/createWebWorkerPromise.js'
 import Mesh from '../core/Mesh.js'
 import InterfaceTypes from '../core/InterfaceTypes.js'
 import PipelineInput from '../pipeline/PipelineInput.js'

--- a/src/io/writeImageArrayBuffer.ts
+++ b/src/io/writeImageArrayBuffer.ts
@@ -1,4 +1,4 @@
-import createWebWorkerPromise from '../core/internal/createWebWorkerPromise.js'
+import createWebWorkerPromise from '../core/createWebWorkerPromise.js'
 
 import Image from '../core/Image.js'
 

--- a/src/io/writeMeshArrayBuffer.ts
+++ b/src/io/writeMeshArrayBuffer.ts
@@ -1,4 +1,4 @@
-import createWebWorkerPromise from '../core/internal/createWebWorkerPromise.js'
+import createWebWorkerPromise from '../core/createWebWorkerPromise.js'
 
 import Mesh from '../core/Mesh.js'
 

--- a/src/pipeline/runPipeline.ts
+++ b/src/pipeline/runPipeline.ts
@@ -1,4 +1,4 @@
-import createWebWorkerPromise from '../core/internal/createWebWorkerPromise.js'
+import createWebWorkerPromise from '../core/createWebWorkerPromise.js'
 import loadEmscriptenModuleMainThread from '../core/internal/loadEmscriptenModuleMainThread.js'
 
 import config from '../itkConfig.js'


### PR DESCRIPTION
This results in:

-    worker = new Worker(new URL('../../web-workers/pipeline.worker.js', import.meta.url))
+    worker = new Worker(new URL('../web-workers/pipeline.worker.js', import.meta.url))

which helps the use case:

1) bundle with rollup
2) bundle the resulting bundle with vite