### PR TITLE
feat(runPipeline): Support specification of pipelineWorkerUrl

### DIFF
--- a/cypress/e2e/pipeline/runPipeline.cy.ts
+++ b/cypress/e2e/pipeline/runPipeline.cy.ts
@@ -58,6 +58,20 @@ describe('runPipeline', () => {
     })
   })
 
+  it('fetches WASM files from a custom pipelineWorkerUrl string', () => {
+    cy.window().then(async (win) => {
+      const itk = win.itk
+      const pipelineBaseUrl = '/pipelines'
+      const pipelineWorkerUrl = '/web-workers/bundles/pipeline.worker.js'
+
+      const args = []
+      const outputs = null
+      const inputs = null
+      const stdoutStderrPath = 'stdout-stderr-test'
+      const { webWorker, returnValue, stdout, stderr } = await itk.runPipeline(null, stdoutStderrPath, args, outputs, inputs, pipelineBaseUrl, pipelineWorkerUrl)
+    })
+  })
+
   it('re-uses a WebWorker', () => {
     cy.window().then(async (win) => {
       const itk = win.itk

--- a/src/pipeline/runPipeline.ts
+++ b/src/pipeline/runPipeline.ts
@@ -47,7 +47,8 @@ async function runPipeline (
   args: string[],
   outputs: PipelineOutput[] | null,
   inputs: PipelineInput[] | null,
-  pipelineBaseUrl: string | URL = 'pipelinesUrl'
+  pipelineBaseUrl: string | URL = 'pipelinesUrl',
+  pipelineWorkerUrl?: string | URL
 ): Promise<RunPipelineResult> {
   if (webWorker === false) {
     const pipelineModule = await loadPipelineModule(pipelinePath.toString())
@@ -55,8 +56,9 @@ async function runPipeline (
     return result
   }
   let worker = webWorker
+  const pipelineWorkerUrlString = typeof pipelineWorkerUrl !== 'string' && typeof pipelineWorkerUrl?.href !== 'undefined' ? pipelineWorkerUrl.href : pipelineWorkerUrl
   const { webworkerPromise, worker: usedWorker } = await createWebWorkerPromise(
-    worker as Worker | null
+    worker as Worker | null, pipelineWorkerUrlString as string | undefined
   )
   worker = usedWorker
   const transferables: ArrayBuffer[] = []


### PR DESCRIPTION
Use case: set to null so vite / webworker vendor.