### PR TITLE
ci(MacOSCxx): Bump Action to use XCode 13.2

### DIFF
--- a/.github/workflows/cxx-python.yml
+++ b/.github/workflows/cxx-python.yml
@@ -9,14 +9,13 @@ env:
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@e63df7ae8a13af6e1bf5b0bcffd45252e133faad
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@03626a23c22246e89e36c7e918a158c440f9b099
     with:
       itk-module-deps: 'MeshToPolyData@v0.10.0'
       ctest-options: '-E itkPipelineTest'
-      warnings-to-ignore: "warning: 'sprintf' is deprecated"
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@e63df7ae8a13af6e1bf5b0bcffd45252e133faad
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@03626a23c22246e89e36c7e918a158c440f9b099
     with:
       itk-module-deps: 'InsightSoftwareConsortium/ITKMeshToPolyData@v0.10.0'
     secrets:


### PR DESCRIPTION
Brings in https://github.com/InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/pull/54 to work around sprintf errors.