### PR TITLE
feat(bindgen): Default to itk-wasm package asset configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,8 @@
       "src/core/internal/loadEmscriptenModuleWebWorker.ts",
       "src/web-workers/*.ts",
       "src/core/ITKWasmEmscriptenModule.ts",
-      "src/pipeline/PipelineEmscriptenModule.ts"
+      "src/pipeline/PipelineEmscriptenModule.ts",
+      "src/bindgen/typescript-resources/*"
     ]
   },
   "release": {

--- a/packages/compress-stringify/typescript/package.json
+++ b/packages/compress-stringify/typescript/package.json
@@ -38,7 +38,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "itk-wasm": "^1.0.0-b.62"
+    "itk-wasm": "^1.0.0-b.65"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",

--- a/packages/compress-stringify/typescript/pnpm-lock.yaml
+++ b/packages/compress-stringify/typescript/pnpm-lock.yaml
@@ -9,7 +9,7 @@ specifiers:
   '@types/node': ^18.11.18
   ava: ^5.1.0
   cypress: ^12.3.0
-  itk-wasm: ^1.0.0-b.62
+  itk-wasm: ^1.0.0-b.65
   rollup: ^3.9.0
   rollup-plugin-copy: ^3.4.0
   rollup-plugin-ignore: ^1.0.10
@@ -20,7 +20,7 @@ specifiers:
   vite-plugin-static-copy: ^0.13.0
 
 dependencies:
-  itk-wasm: 1.0.0-b.62
+  itk-wasm: 1.0.0-b.65
 
 devDependencies:
   '@rollup/plugin-commonjs': 24.0.0_rollup@3.9.1
@@ -752,7 +752,6 @@ packages:
 
   /balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-    dev: true
 
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -792,7 +791,6 @@ packages:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
     dependencies:
       balanced-match: 1.0.2
-    dev: true
 
   /braces/3.0.2:
     resolution: {integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==}
@@ -1489,7 +1487,6 @@ packages:
 
   /fs.realpath/1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-    dev: true
 
   /fsevents/2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -1560,6 +1557,17 @@ packages:
       minimatch: 5.1.2
       once: 1.4.0
     dev: true
+
+  /glob/8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.2
+      once: 1.4.0
+    dev: false
 
   /global-dirs/3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
@@ -1661,11 +1669,9 @@ packages:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
-    dev: true
 
   /inherits/2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: true
 
   /ini/2.0.0:
     resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
@@ -1809,8 +1815,8 @@ packages:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
     dev: true
 
-  /itk-wasm/1.0.0-b.62:
-    resolution: {integrity: sha512-A5PEHEGtJ/ZPphaa1KNiRF+jSX5RLNjuaEwkRXtRzrRxo7TnDkSQR/vrSNtj9cYL0SQQtLAXjHbDn/UJUAD43A==}
+  /itk-wasm/1.0.0-b.65:
+    resolution: {integrity: sha512-BXLq0cHzDyyerJ+dPOWx4qP8/ouoaM7A20fm2jkJZ8QLtXoJ1HfBzz8RBJ+pxdNYNNFIfswWxGBIZ5YqvjtdZg==}
     hasBin: true
     dependencies:
       '@babel/runtime': 7.20.7
@@ -1818,6 +1824,7 @@ packages:
       axios: 0.23.0
       commander: 9.5.0
       fs-extra: 10.1.0
+      glob: 8.1.0
       markdown-table: 3.0.3
       mime-types: 2.1.35
       promise-file-reader: 1.0.3
@@ -2046,7 +2053,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
-    dev: true
 
   /minimist/1.2.7:
     resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
@@ -2087,7 +2093,6 @@ packages:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
     dependencies:
       wrappy: 1.0.2
-    dev: true
 
   /onetime/5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -2827,7 +2832,6 @@ packages:
 
   /wrappy/1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-    dev: true
 
   /write-file-atomic/5.0.0:
     resolution: {integrity: sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==}

--- a/packages/compress-stringify/typescript/src/pipeline-worker-url.ts
+++ b/packages/compress-stringify/typescript/src/pipeline-worker-url.ts
@@ -1,10 +1,21 @@
+// @ts-ignore: TS2305: Module '"itk-wasm"' has no exported member 'getPipelineWorkerUrl'.
+import { getPipelineWorkerUrl as itkWasmGetPipelineWorkerUrl } from 'itk-wasm'
 import packageJson from '../package.json'
-let pipelineWorkerUrl: string | URL | null = `https://cdn.jsdelivr.net/npm/itk-compress-stringify@${packageJson.version}/dist/web-workers/pipeline.worker.js`
+
+let pipelineWorkerUrl: string | URL | null | undefined
+let defaultPipelineWorkerUrl: string | URL | null = `https://cdn.jsdelivr.net/npm/itk-compress-stringify@${packageJson.version}/dist/web-workers/pipeline.worker.js`
 
 export function setPipelineWorkerUrl (workerUrl: string | URL | null): void {
   pipelineWorkerUrl = workerUrl
 }
 
 export function getPipelineWorkerUrl (): string | URL | null {
-  return pipelineWorkerUrl
+  if (typeof pipelineWorkerUrl !== 'undefined') {
+    return pipelineWorkerUrl
+  }
+  const itkWasmPipelineWorkerUrl = itkWasmGetPipelineWorkerUrl()
+  if (typeof itkWasmPipelineWorkerUrl !== 'undefined') {
+    return itkWasmPipelineWorkerUrl
+  }
+  return defaultPipelineWorkerUrl
 }

--- a/packages/compress-stringify/typescript/src/pipelines-base-url.ts
+++ b/packages/compress-stringify/typescript/src/pipelines-base-url.ts
@@ -1,10 +1,21 @@
+// @ts-ignore: TS2305: Module '"itk-wasm"' has no exported member 'getPipelinesBaseUrl'.
+import { getPipelinesBaseUrl as itkWasmGetPipelinesBaseUrl } from 'itk-wasm'
 import packageJson from '../package.json'
-let pipelinesBaseUrl: string | URL = `https://cdn.jsdelivr.net/npm/itk-compress-stringify@${packageJson.version}/dist/pipelines`
+
+let pipelinesBaseUrl: string | URL | undefined
+const defaultPipelinesBaseUrl = `https://cdn.jsdelivr.net/npm/itk-compress-stringify@${packageJson.version}/dist/pipelines`
 
 export function setPipelinesBaseUrl (baseUrl: string | URL): void {
   pipelinesBaseUrl = baseUrl
 }
 
 export function getPipelinesBaseUrl (): string | URL {
-  return pipelinesBaseUrl
+  if (typeof pipelinesBaseUrl !== 'undefined') {
+    return pipelinesBaseUrl
+  }
+  const itkWasmPipelinesBaseUrl = itkWasmGetPipelinesBaseUrl()
+  if (typeof itkWasmPipelinesBaseUrl !== 'undefined') {
+    return itkWasmPipelinesBaseUrl
+  }
+  return defaultPipelinesBaseUrl
 }

--- a/packages/compress-stringify/typescript/test/browser/app.ts
+++ b/packages/compress-stringify/typescript/test/browser/app.ts
@@ -1,4 +1,5 @@
 import * as itkCompressStringify from '../../dist/bundles/itk-compress-stringify.js'
+import * as itkWasm from 'itk-wasm'
 
 // Use local, vendored WebAssembly module assets
 const pipelinesBaseUrl: string | URL = new URL('/pipelines', document.location.origin).href

--- a/src/bindgen/typescript-resources/pipeline-worker-url.ts
+++ b/src/bindgen/typescript-resources/pipeline-worker-url.ts
@@ -1,4 +1,3 @@
-// @ts-ignore: TS2305: Module '"itk-wasm"' has no exported member 'getPipelineWorkerUrl'.
 import { getPipelineWorkerUrl as itkWasmGetPipelineWorkerUrl } from 'itk-wasm'
 import packageJson from '../package.json'
 

--- a/src/bindgen/typescript-resources/pipeline-worker-url.ts
+++ b/src/bindgen/typescript-resources/pipeline-worker-url.ts
@@ -1,11 +1,21 @@
-// @ts-expect-error error TS2732: Cannot find module '../package.json'. Consider using '--resolveJsonModule' to import module with '.json' extension.
+// @ts-ignore: TS2305: Module '"itk-wasm"' has no exported member 'getPipelineWorkerUrl'.
+import { getPipelineWorkerUrl as itkWasmGetPipelineWorkerUrl } from 'itk-wasm'
 import packageJson from '../package.json'
-let pipelineWorkerUrl: string | URL | null = `https://cdn.jsdelivr.net/npm/<bindgenPackageName>@${packageJson.version as string}/dist/web-workers/pipeline.worker.js`
+
+let pipelineWorkerUrl: string | URL | null | undefined
+const defaultPipelineWorkerUrl = `https://cdn.jsdelivr.net/npm/<bindgenPackageName>@${packageJson.version}/dist/web-workers/pipeline.worker.js`
 
 export function setPipelineWorkerUrl (workerUrl: string | URL | null): void {
   pipelineWorkerUrl = workerUrl
 }
 
 export function getPipelineWorkerUrl (): string | URL | null {
-  return pipelineWorkerUrl
+  if (typeof pipelineWorkerUrl !== 'undefined') {
+    return pipelineWorkerUrl
+  }
+  const itkWasmPipelineWorkerUrl = itkWasmGetPipelineWorkerUrl()
+  if (typeof itkWasmPipelineWorkerUrl !== 'undefined') {
+    return itkWasmPipelineWorkerUrl
+  }
+  return defaultPipelineWorkerUrl
 }

--- a/src/bindgen/typescript-resources/pipelines-base-url.ts
+++ b/src/bindgen/typescript-resources/pipelines-base-url.ts
@@ -1,4 +1,3 @@
-// @ts-ignore: TS2305: Module '"itk-wasm"' has no exported member 'getPipelinesBaseUrl'.
 import { getPipelinesBaseUrl as itkWasmGetPipelinesBaseUrl } from 'itk-wasm'
 import packageJson from '../package.json'
 

--- a/src/bindgen/typescript-resources/pipelines-base-url.ts
+++ b/src/bindgen/typescript-resources/pipelines-base-url.ts
@@ -1,11 +1,21 @@
-// @ts-expect-error error TS2732: Cannot find module '../package.json'. Consider using '--resolveJsonModule' to import module with '.json' extension.
+// @ts-ignore: TS2305: Module '"itk-wasm"' has no exported member 'getPipelinesBaseUrl'.
+import { getPipelinesBaseUrl as itkWasmGetPipelinesBaseUrl } from 'itk-wasm'
 import packageJson from '../package.json'
-let pipelinesBaseUrl: string | URL = `https://cdn.jsdelivr.net/npm/<bindgenPackageName>@${packageJson.version as string}/dist/pipelines`
+
+let pipelinesBaseUrl: string | URL | undefined
+let defaultPipelinesBaseUrl: string | URL = `https://cdn.jsdelivr.net/npm/itk-compress-stringify@${packageJson.version}/dist/pipelines`
 
 export function setPipelinesBaseUrl (baseUrl: string | URL): void {
   pipelinesBaseUrl = baseUrl
 }
 
 export function getPipelinesBaseUrl (): string | URL {
-  return pipelinesBaseUrl
+  if (typeof pipelinesBaseUrl !== 'undefined') {
+    return pipelinesBaseUrl
+  }
+  const itkWasmPipelinesBaseUrl = itkWasmGetPipelinesBaseUrl()
+  if (typeof itkWasmPipelinesBaseUrl !== 'undefined') {
+    return itkWasmPipelinesBaseUrl
+  }
+  return defaultPipelinesBaseUrl
 }

--- a/src/bindgen/typescript-resources/template.package.json
+++ b/src/bindgen/typescript-resources/template.package.json
@@ -30,7 +30,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "itk-wasm": "^1.0.0-b.62"
+    "itk-wasm": "^1.0.0-b.65"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "typeRoots": ["./node_modules/@types", "./src/vendor-types"]
   },
   "include": ["./src/**/*"],
-  "exclude": ["./src/core/internal/loadEmscriptenModuleWebWorker.ts", "./src/web-workers/*"]
+  "exclude": ["./src/core/internal/loadEmscriptenModuleWebWorker.ts", "./src/web-workers/*", "src/bindgen/typescript-resources/*"]
 }


### PR DESCRIPTION
At runtime, we use in order of preference:

1. Package asset configuration
2. itk-wasm asset configuration
3. jsDeliver