### PR TITLE
fix(DebuggingExample): Bump itk-wasm version for missing fs-extra dep

### DIFF
--- a/examples/debugging/package.json
+++ b/examples/debugging/package.json
@@ -21,6 +21,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "http-server": "^14.1.0",
-    "itk-wasm": "^1.0.0-b.6"
+    "itk-wasm": "^1.0.0-b.77"
   }
 }


### PR DESCRIPTION
To address:

```
> itk-wasm-debugging-example@1.0.1 wasi-build-debug /home/local/KHQ/will.schroeder/Develop/wasm/itk-wasm/examples/debugging
> itk-wasm -i itkwasm/wasi --build-dir wasi-build-debug build -- -DCMAKE_BUILD_TYPE=Debug

/home/local/KHQ/will.schroeder/Develop/wasm/itk-wasm/examples/debugging/node_modules/itk-wasm/src/itk-wasm-cli.js:3
import fs from 'fs-extra'
```