### PR TITLE
docs(HelloWorld): Update itk-wasm version to 1.0.0-b83

### DIFF
--- a/docs/tutorial/hello_world.md
+++ b/docs/tutorial/hello_world.md
@@ -48,7 +48,7 @@ Build the program with the itk-wasm CLI, `itk-wasm`. This is shipped with the `i
 ```sh
 # Initialize an empty project in the current directory
 npm init --yes
-npm install itk-wasm@1.0.0-b.72
+npm install itk-wasm@1.0.0-b.83
 ```
 
 ## WASI


### PR DESCRIPTION
Fixes the default build directory for wasi.