### PR TITLE
feat(CLI): Add --test-dir option to test subcommand

### DIFF
--- a/src/docker/itk-wasm-base/wasmtime-pwd.sh
+++ b/src/docker/itk-wasm-base/wasmtime-pwd.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-# Mount the PWD to enable access in try_run commands
-exec ${WasmTIME_HOME}/bin/wasmtime run --dir=. --dir=$PWD "$@"


### PR DESCRIPTION
Enables running ctest from a subdirectory of the build tree.

Also improve flag documentation.

Remove unused wasmtime-pwd.sh

This is in the dockcross image.