### PR TITLE
Bindgen patches

### DIFF
--- a/src/bindgen/python.js
+++ b/src/bindgen/python.js
@@ -22,6 +22,7 @@ const interfaceJsonTypeToPythonType = new Map([
   ['BOOL', 'bool'],
   ['TEXT', 'str'],
   ['INT', 'int'],
+  ['UINT', 'int'],
   ['FLOAT', 'float'],
   ['OUTPUT_JSON', 'Dict'],
 ])

--- a/src/bindgen/typescript-resources/pipelines-base-url.ts
+++ b/src/bindgen/typescript-resources/pipelines-base-url.ts
@@ -2,7 +2,7 @@ import { getPipelinesBaseUrl as itkWasmGetPipelinesBaseUrl } from 'itk-wasm'
 import packageJson from '../package.json'
 
 let pipelinesBaseUrl: string | URL | undefined
-let defaultPipelinesBaseUrl: string | URL = `https://cdn.jsdelivr.net/npm/@itk-wasm/compress-stringify@${packageJson.version}/dist/pipelines`
+let defaultPipelinesBaseUrl: string | URL = `https://cdn.jsdelivr.net/npm/<bindgenPackageName>@${packageJson.version}/dist/pipelines`
 
 export function setPipelinesBaseUrl (baseUrl: string | URL): void {
   pipelinesBaseUrl = baseUrl

--- a/src/bindgen/typescript.js
+++ b/src/bindgen/typescript.js
@@ -23,6 +23,7 @@ const interfaceJsonTypeToTypeScriptType = new Map([
   ['BOOL', 'boolean'],
   ['TEXT', 'string'],
   ['INT', 'number'],
+  ['UINT', 'number'],
   ['FLOAT', 'number'],
   ['OUTPUT_JSON', 'Object'],
 ])

--- a/src/itk-wasm-cli.js
+++ b/src/itk-wasm-cli.js
@@ -255,6 +255,7 @@ function bindgen(options) {
   switch (language) {
     case 'typescript':
       typescriptBindgen(outputDir, buildDir, filteredWasmBinaries, options)
+    break
     case 'python':
       pythonBindgen(outputDir, buildDir, filteredWasmBinaries, options)
     break


### PR DESCRIPTION
- Support unsigned integer as pipeline parameter.  
- Only generate bindgen for specified language.
- Default CDN url uses package name.