### PR TITLE
fix: Use pathToFileURL for loading js module on Windows

### DIFF
--- a/src/core/internal/loadEmscriptenModuleNode.ts
+++ b/src/core/internal/loadEmscriptenModuleNode.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import EmscriptenModule from '../ITKWasmEmscriptenModule.js'
+import { pathToFileURL } from 'url'
 
 async function loadEmscriptenModuleNode (modulePath: string): Promise<EmscriptenModule> {
   let modulePrefix = modulePath
@@ -11,7 +12,7 @@ async function loadEmscriptenModuleNode (modulePath: string): Promise<Emscripten
   }
   const wasmBinaryPath = `${modulePrefix}.wasm`
   const wasmBinary = fs.readFileSync(wasmBinaryPath)
-  const fullModulePath = `${modulePrefix}.js`
+  const fullModulePath = pathToFileURL(`${modulePrefix}.js`).href
   const result = await import(/* webpackIgnore: true */ /* @vite-ignore */ fullModulePath)
   const instantiated = result.default({ wasmBinary }) as EmscriptenModule
   return instantiated


### PR DESCRIPTION
Required for loading a module on Windows in Node 18.