### PR TITLE
fix(package): add types entry to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "browser": "./dist/browser/index.js",
       "import": "./dist/node/index.js",
       "umd": "./dist/umd/itk-wasm.js",


### PR DESCRIPTION
Allows Typescript project to use `nodenext` module resolution strategy.

```json
"compilerOptions": {
    "moduleResolution": "nodenext"
}
```
More info:
https://moonrepo.dev/docs/guides/javascript/typescript-project-refs#enabling-importsexports-resolution

and of course:
https://nodejs.org/api/packages.html#community-conditions-definitions