### PR TITLE
feat(bindgen): Add pyproject.toml project.urls

### DIFF
--- a/src/bindgen/python-resources/template.pyproject.toml
+++ b/src/bindgen/python-resources/template.pyproject.toml
@@ -42,6 +42,9 @@ dependencies = [
   "pytest",@bindgenHatchEnvDependencies@
 ]
 
+[project.urls]
+Home = "@bindgenProjectRepository@"
+Source = "@bindgenProjectRepository@"
 @bindgenHatchEnvScripts@
 
 [tool.hatch.build]


### PR DESCRIPTION
Home is expected to be replaced by the built project documentation after it has been published.