### PR TITLE
fix(bindgen): Bump typescript package deps

### DIFF
--- a/src/bindgen/typescript-resources/template.package.json
+++ b/src/bindgen/typescript-resources/template.package.json
@@ -30,23 +30,23 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "itk-wasm": "^1.0.0-b.101"
+    "itk-wasm": "^1.0.0-b.112"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",
     "@rollup/plugin-json": "^6.0.0",
-    "@rollup/plugin-node-resolve": "^15.0.1",
+    "@rollup/plugin-node-resolve": "^15.1.0",
     "@rollup/plugin-terser": "^0.4.0",
-    "@rollup/plugin-typescript": "^10.0.1",
-    "@types/node": "^18.13.0",
+    "@rollup/plugin-typescript": "^11.1.1",
+    "@types/node": "^20.2.5",
     "debug": "^4.3.4",
     "rollup": "^3.9.0",
     "rollup-plugin-copy": "^3.4.0",
     "rollup-plugin-ignore": "^1.0.10",
-    "rollup-plugin-polyfill-node": "^0.11.0",
+    "rollup-plugin-polyfill-node": "^0.12.0",
     "supports-color": "^9.3.1",
-    "tslib": "^2.5.0",
-    "typescript": "^4.9.4",
+    "tslib": "^2.5.2",
+    "typescript": "^5.0.4",
     "vite": "^4.0.4",
     "vite-plugin-static-copy": "^0.13.0"
   }


### PR DESCRIPTION
To address:

[!] RollupError: "TextEncoder" is not exported by "polyfill-node.util.js", imported by "node_modules/axios/lib/helpers/formDataToStream.js". 64
https://rollupjs.org/troubleshooting/#error-name-is-not-exported-by-module 65
node_modules/axios/lib/helpers/formDataToStream.js (1:8) 66
1: import {TextEncoder} from 'util';
67
           ^