### PR TITLE
build(mean-squares-version-registration): Bump itk-wasm to 1.0.0-b.114

### DIFF
--- a/examples/mean-squares-versor-registration/package.json
+++ b/examples/mean-squares-versor-registration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itk-wasm/mean-squares-versor-registration",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Illustrate the use of the VersorRigid3DTransform for 3D image registration.",
   "type": "module",
   "scripts": {
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "fs-extra": "^10.0.0",
-    "itk-image-io": "^1.0.0-b.89",
-    "itk-wasm": "^1.0.0-b.89"
+    "itk-image-io": "^1.0.0-b.114",
+    "itk-wasm": "^1.0.0-b.114"
   }
 }


### PR DESCRIPTION
Addresses:

```
[!] RollupError: "TextEncoder" is not exported by "polyfill-node.util.js",
imported by "node_modules/axios/lib/helpers/formDataToStream.js".
64
https://rollupjs.org/troubleshooting/#error-name-is-not-exported-by-module
65
node_modules/axios/lib/helpers/formDataToStream.js (1:8)
66
1: import {TextEncoder} from 'util';
67
           ^
```