### PR TITLE
test(dicom): test multiple SOP classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "commit": "git cz",
     "bindgen": "node ./src/itk-wasm-cli.js bindgen ./dist/dicom/src ./dist/dicom/public/pipelines/*.wasm",
     "build": "npm run build:testData && npm run build:emscripten && npm run build:tsc && npm run build:tscWorkersModuleLoader && npm run build:tscWebWorkers && npm run build:workerBundles && npm run build:workerMinBundles && npm run build:webpack && node ./src/io/internal/packages/package-json-gen.cjs && npm run build:emscripten:packages",
-    "build:testData": "dam download packages/dicom/test/data packages/dicom/test/data.tar.gz bafybeic2ckitzhl5b476fgfewt7ilel3mkzi5x66o6gga5s7n34g2t36xm https://github.com/InsightSoftwareConsortium/itk-wasm/releases/download/itk-wasm-v1.0.0-b.113/test-data.tar.gz https://w3s.link/ipfs/bafkreibxuanogkwccski66azxafdpjjj3sbua6g3pqdvwwwe72h3d6agoi",
+    "build:testData": "dam download packages/dicom/test/data packages/dicom/test/data.tar.gz bafybeif4qahwzxa2gb76fiuh7b5tdnqrieoa6zm2hsuywn4a54yrb24ufa https://w3s.link/ipfs/bafybeih2uapx7fk5pqdhi6gshhr6o7frbzdznhvack3h543pu3vietjq4u",
     "build:debug": "npm run build:emscripten -- --debug && npm run build:tsc && npm run build:tscWorkersModuleLoader && npm run build:tscWebWorkers && npm run build:workerBundles && npm run build:workerMinBundles && npm run build:webpack -- --mode development",
     "build:tsc": "tsc --pretty",
     "build:tscWorkersModuleLoader": "tsc --types --lib es2017,webworker --rootDir ./src/ --outDir ./dist/ --moduleResolution node --target es2017 --module es2020 --strict --forceConsistentCasingInFileNames --declaration ./src/core/internal/loadEmscriptenModuleWebWorker.ts",

--- a/packages/dicom/typescript/test/node.js
+++ b/packages/dicom/typescript/test/node.js
@@ -6,7 +6,7 @@ import {
   readDicomEncapsulatedPdfNode,
   applyPresentationStateToImageNode,
 } from '../dist/bundles/dicom-node.js'
-import { readImageLocalFile } from '../../../../dist/index.js'
+import { readImageLocalFile, readImageLocalDICOMFileSeries, readDICOMTagsLocalFile } from '../../../../dist/index.js'
 
   function arrayEquals(a, b) {
     return (a.length === b.length && a.every((val, idx) => val === b[idx]))
@@ -217,4 +217,258 @@ test('Apply color presentation state (CSPS) to a color dicom image.', async t =>
   const baselinePixels = await readImageLocalFile(baselineImageFilePath)
   t.assert(baselinePixels.data.length === outputImage.data.length)
   t.assert(Buffer.compare(baselinePixels.data, outputImage.data) === 0)
+})
+
+// ------------------------------------
+// Test DICOM SOP Classes
+// ------------------------------------
+
+test('DICOM SOP: Ultrasound Image Storage.', async t => {
+  const inputFilePath = testPathPrefix + 'dicom-images/ultrasound.dcm'
+
+  const outputTags = await readDICOMTagsLocalFile(inputFilePath)
+  // console.log(outputTags)
+  t.assert(outputTags.get('0008|0016') === '1.2.840.10008.5.1.4.1.1.6.1')
+
+  const outputImage = await readImageLocalDICOMFileSeries([inputFilePath])
+  // console.log('US outputImage: ', outputImage)
+  t.assert(outputImage != null)
+  t.assert(outputImage.imageType.componentType === 'uint8')
+  t.assert(outputImage.imageType.pixelType === 'Vector')
+  t.assert(outputImage.imageType.components === 3)
+  t.assert(arrayEquals(outputImage.origin, [0, 0, 0]))
+  t.assert(arrayEquals(outputImage.spacing, [0.220751, 0.220751, 1]))
+  t.assert(arrayEquals(outputImage.direction, [1, 0, 0, 0, 1, 0, 0, 0, 1]))
+  t.assert(arrayEquals(outputImage.size, [1024, 768, 1]))
+})
+
+test('DICOM SOP: Secondary Image Storage.', async t => {
+  const inputFilePath = testPathPrefix + 'dicom-images/secondary-capture.dcm'
+
+  const outputTags = await readDICOMTagsLocalFile(inputFilePath)
+  // console.log(outputTags)
+  t.assert(outputTags.get('0008|0016') === '1.2.840.10008.5.1.4.1.1.7')
+
+  const outputImage = await readImageLocalDICOMFileSeries([inputFilePath])
+  // console.log('Secondary Capture outputImage: ', outputImage)
+  t.assert(outputImage != null)
+  t.assert(outputImage.imageType.componentType === 'uint8')
+  t.assert(outputImage.imageType.pixelType === 'Scalar')
+  t.assert(outputImage.imageType.components === 1)
+  t.assert(arrayEquals(outputImage.origin, [0, 0, 0]))
+  t.assert(arrayEquals(outputImage.spacing, [1, 1, 1]))
+  t.assert(arrayEquals(outputImage.direction, [1, 0, 0, 0, 1, 0, 0, 0, 1]))
+  t.assert(arrayEquals(outputImage.size, [960, 720, 1]))
+})
+
+test('DICOM SOP: Segmentation Storage.', async t => {
+  const inputFilePath = testPathPrefix + 'dicom-images/segmentation-storage.dcm'
+
+  const outputTags = await readDICOMTagsLocalFile(inputFilePath)
+  // console.log(outputTags)
+  t.assert(outputTags.get('0008|0016') === '1.2.840.10008.5.1.4.1.1.66.4')
+
+  const outputImage = await readImageLocalDICOMFileSeries([inputFilePath])
+  // console.log('Secondary Capture outputImage: ', outputImage)
+  t.assert(outputImage != null)
+  t.assert(outputImage.imageType.componentType === 'uint8')
+  t.assert(outputImage.imageType.pixelType === 'Scalar')
+  t.assert(outputImage.imageType.components === 1)
+  t.assert(arrayEquals(outputImage.origin, [14.043, 101.425, -73.0513]))
+  t.assert(arrayEquals(outputImage.spacing, [0.6055, 0.6055, 2]))
+  t.assert(arrayEquals(outputImage.direction, [-1, 0, 0, 0, -1, 0, 0, 0, 1]))
+  t.assert(arrayEquals(outputImage.size, [256, 256, 80]))
+})
+
+test('DICOM SOP: Computed Radiography.', async t => {
+  const inputFilePath = testPathPrefix + 'dicom-images/computed-radiography.dcm'
+
+  const outputTags = await readDICOMTagsLocalFile(inputFilePath)
+  // console.log(outputTags)
+  t.assert(outputTags.get('0008|0016') === '1.2.840.10008.5.1.4.1.1.1')
+
+  const outputImage = await readImageLocalDICOMFileSeries([inputFilePath])
+  // console.log('Secondary Capture outputImage: ', outputImage)
+  t.assert(outputImage != null)
+  t.deepEqual(outputImage.imageType.componentType, 'uint16')
+  t.deepEqual(outputImage.imageType.pixelType , 'Scalar')
+  t.deepEqual(outputImage.imageType.components, 1)
+  t.deepEqual(outputImage.origin, [0, 0, 0])
+  t.deepEqual(outputImage.spacing, [0.139, 0.139, 1])
+  t.deepEqual(outputImage.direction, Float64Array.from([1, 0, 0, 0, 1, 0, 0, 0, 1]))
+  t.deepEqual(outputImage.size, [2366, 2194, 1])
+})
+
+test('DICOM SOP: Digital X-Ray Image.', async t => {
+  const inputFilePath = testPathPrefix + 'dicom-images/digital-chest-xray.dcm'
+
+  const outputTags = await readDICOMTagsLocalFile(inputFilePath)
+  // console.log(outputTags)
+  t.assert(outputTags.get('0008|0016') === '1.2.840.10008.5.1.4.1.1.1.1')
+
+  const outputImage = await readImageLocalDICOMFileSeries([inputFilePath])
+  // console.log('Secondary Capture outputImage: ', outputImage)
+  t.assert(outputImage != null)
+  t.deepEqual(outputImage.imageType.componentType, 'uint16')
+  t.deepEqual(outputImage.imageType.pixelType , 'Scalar')
+  t.deepEqual(outputImage.imageType.components, 1)
+  t.deepEqual(outputImage.origin, [0, 0, 0])
+  t.deepEqual(outputImage.spacing, [0.148, 0.148, 1])
+  t.deepEqual(outputImage.direction, Float64Array.from([1, 0, 0, 0, 1, 0, 0, 0, 1]))
+  t.deepEqual(outputImage.size, [2656, 2330, 1])
+})
+
+test('DICOM SOP: Digital Mammography X-Ray Image Storage.', async t => {
+  const inputFilePath = testPathPrefix + 'dicom-images/digital-mammography-xray.dcm'
+
+  const outputTags = await readDICOMTagsLocalFile(inputFilePath)
+  // console.log(outputTags)
+  t.assert(outputTags.get('0008|0016') === '1.2.840.10008.5.1.4.1.1.1.2')
+
+  const outputImage = await readImageLocalDICOMFileSeries([inputFilePath])
+  // console.log('Secondary Capture outputImage: ', outputImage)
+  t.assert(outputImage != null)
+  t.deepEqual(outputImage.imageType.componentType, 'uint16')
+  t.deepEqual(outputImage.imageType.pixelType , 'Scalar')
+  t.deepEqual(outputImage.imageType.components, 1)
+  t.deepEqual(outputImage.origin, [0, 0, 0])
+  t.deepEqual(outputImage.spacing, [0.07, 0.07, 1])
+  t.deepEqual(outputImage.direction, Float64Array.from([1, 0, 0, 0, 1, 0, 0, 0, 1]))
+  t.deepEqual(outputImage.size, [2560, 3328, 1])
+})
+
+test('DICOM SOP: RT Dose Storage.', async t => {
+  const inputFilePath = testPathPrefix + 'dicom-images/RT-dose.dcm'
+
+  const outputTags = await readDICOMTagsLocalFile(inputFilePath)
+  // console.log(outputTags)
+  t.assert(outputTags.get('0008|0016') === '1.2.840.10008.5.1.4.1.1.481.2')
+
+  const outputImage = await readImageLocalDICOMFileSeries([inputFilePath])
+  // console.log('Secondary Capture outputImage: ', outputImage)
+  t.assert(outputImage != null)
+  t.deepEqual(outputImage.imageType.dimension, 3)
+  t.deepEqual(outputImage.imageType.componentType, 'uint16')
+  t.deepEqual(outputImage.imageType.pixelType , 'Scalar')
+  t.deepEqual(outputImage.imageType.components, 1)
+  t.deepEqual(outputImage.origin, [-87.4346184, -122.593791, 93.125896])
+  t.deepEqual(outputImage.spacing, [1, 1, 1])
+  t.deepEqual(outputImage.direction, Float64Array.from([
+    1, 2.05103388e-10, -3.5609435582144703e-28,
+    -2.05103388e-10, 1, -1.73617002e-18,
+    -2.575419273602761e-36, -1.73617002e-18, -1
+  ]))
+  t.deepEqual(outputImage.size, [163, 203, 200])
+})
+
+test('DICOM SOP: Ultrasound Multi-frame Image Storage.', async t => {
+  const inputFilePath = testPathPrefix + 'dicom-images/multiframe-ultrasound.dcm'
+
+  const outputTags = await readDICOMTagsLocalFile(inputFilePath)
+  // console.log(outputTags)
+  t.assert(outputTags.get('0008|0016') === '1.2.840.10008.5.1.4.1.1.3.1')
+
+  const outputImage = await readImageLocalDICOMFileSeries([inputFilePath])
+  // console.log('Secondary Capture outputImage: ', outputImage)
+  t.assert(outputImage != null)
+  t.deepEqual(outputImage.imageType.dimension, 3)
+  t.deepEqual(outputImage.imageType.componentType, 'uint8')
+  t.deepEqual(outputImage.imageType.pixelType , 'Scalar')
+  t.deepEqual(outputImage.imageType.components, 1)
+  t.deepEqual(outputImage.origin, [0, 0, 0])
+  t.deepEqual(outputImage.spacing, [0.356, 0.356, 1])
+  t.deepEqual(outputImage.direction, Float64Array.from([1, 0, 0, 0, 1, 0, 0, 0, 1]))
+  t.deepEqual(outputImage.size, [352, 352, 227])
+})
+
+test('DICOM SOP: Positron Emission Tomography Image Storage.', async t => {
+  const inputFilePath = testPathPrefix + 'dicom-images/PET'
+  const files = fs.readdirSync(inputFilePath).map(fileName => inputFilePath + '/' + fileName)
+
+  const outputTags = await readDICOMTagsLocalFile(files[0])
+  // console.log(outputTags)
+  t.assert(outputTags.get('0008|0016') === '1.2.840.10008.5.1.4.1.1.128')
+
+  const outputImage = await readImageLocalDICOMFileSeries(files)
+  // console.log('Secondary Capture outputImage: ', outputImage)
+  t.assert(outputImage != null)
+  t.deepEqual(outputImage.imageType.dimension, 3)
+  t.deepEqual(outputImage.imageType.componentType, 'float64')
+  t.deepEqual(outputImage.imageType.pixelType , 'Scalar')
+  t.deepEqual(outputImage.imageType.components, 1)
+  t.deepEqual(outputImage.origin, [-342.402, -553.182, -676])
+  t.deepEqual(outputImage.spacing, [ 4.07283, 4.07283, 3])
+  t.deepEqual(outputImage.direction, Float64Array.from([1, 0, 0, 0, 1, 0, 0, 0, 1]))
+  t.deepEqual(outputImage.size, [168, 168, 251])
+})
+
+test('DICOM SOP: CT Image.', async t => {
+  const inputFilePath = testPathPrefix + 'dicom-images/CT'
+  const files = fs.readdirSync(inputFilePath).map(fileName => inputFilePath + '/' + fileName)
+
+  const outputTags = await readDICOMTagsLocalFile(files[0])
+  // console.log(outputTags)
+  t.assert(outputTags.get('0008|0016') === '1.2.840.10008.5.1.4.1.1.2')
+
+  const outputImage = await readImageLocalDICOMFileSeries(files)
+  // console.log('Secondary Capture outputImage: ', outputImage)
+  t.assert(outputImage != null)
+  t.deepEqual(outputImage.imageType.dimension, 3)
+  t.deepEqual(outputImage.imageType.componentType, 'int16')
+  t.deepEqual(outputImage.imageType.pixelType , 'Scalar')
+  t.deepEqual(outputImage.imageType.components, 1)
+  t.deepEqual(outputImage.origin, [-511, -181, -2])
+  t.deepEqual(outputImage.spacing, [2, 2, 223.66743882476638])
+  t.deepEqual(outputImage.direction, Float64Array.from([1, 0, -6.123031769e-17, 6.123031769e-17, 0, 1, 0, -1, 0]))
+  t.deepEqual(outputImage.size, [512, 512, 2])
+})
+
+test('DICOM SOP: MR Image.', async t => {
+  const inputFilePath = testPathPrefix + 'dicom-images/MR'
+  const files = fs.readdirSync(inputFilePath).map(fileName => inputFilePath + '/' + fileName)
+
+  const outputTags = await readDICOMTagsLocalFile(files[0])
+  // console.log(outputTags)
+  t.assert(outputTags.get('0008|0016') === '1.2.840.10008.5.1.4.1.1.4')
+
+  const outputImage = await readImageLocalDICOMFileSeries(files)
+  // console.log('Secondary Capture outputImage: ', outputImage)
+  t.assert(outputImage != null)
+  t.deepEqual(outputImage.imageType.dimension, 3)
+  t.deepEqual(outputImage.imageType.componentType, 'uint16')
+  t.deepEqual(outputImage.imageType.pixelType , 'Scalar')
+  t.deepEqual(outputImage.imageType.components, 1)
+  t.deepEqual(outputImage.origin, [-156.46333984047, -142.7302360186, -54.341191112995])
+  t.deepEqual(outputImage.spacing, [1.0625, 1.0625, 1.399999976158])
+  t.deepEqual(outputImage.direction, Float64Array.from([ 1, 2.051034e-10, 0, -2.051034e-10, 1, 0, 0, 0, 1 ]))
+  t.deepEqual(outputImage.size, [320, 320, 5])
+})
+
+test('DICOM SOP: Nuclear Medicine Image.', async t => {
+  const inputFilePath = testPathPrefix + 'dicom-images/nuclear-medicine.dcm'
+  const outputTags = await readDICOMTagsLocalFile(inputFilePath)
+  // console.log(outputTags)
+  t.assert(outputTags.get('0008|0016') === '1.2.840.10008.5.1.4.1.1.20')
+
+  const outputImage = await readImageLocalDICOMFileSeries([inputFilePath])
+  // console.log('Secondary Capture outputImage: ', outputImage)
+  t.assert(outputImage != null)
+  t.deepEqual(outputImage.imageType.dimension, 3)
+  t.deepEqual(outputImage.imageType.componentType, 'uint16')
+  t.deepEqual(outputImage.imageType.pixelType , 'Scalar')
+  t.deepEqual(outputImage.imageType.components, 1)
+  t.deepEqual(outputImage.origin, [-304.64869833601, -459.38798370462, 1437.200400138])
+  t.deepEqual(outputImage.spacing, [4.7951998710632, 4.7951998710632, 4.7951998710632])
+  t.deepEqual(outputImage.direction, Float64Array.from([
+      0.999984923263527,
+      -0.00024031414620000064,
+      0.005485936086894437,
+      0.0003446298565238277,
+      0.9998190041416027,
+      -0.019022097349032426,
+      -0.005480371876099911,
+      0.019023701175250058,
+      0.9998040129533861
+  ]))
+  t.deepEqual(outputImage.size, [128, 128, 69])
 })


### PR DESCRIPTION
Total DICOM SOP test cases (including previously existing tests):

Non-Image SOPs:
  ✔ read Radiation Dose SR (477ms)
  ✔ Apply presentation state to dicom image. (521ms)
  ✔ read Key Object Selection SR (558ms)
  ✔ structuredReportToText (593ms)
  ✔ readDicomEncapsulatedPdfNode (604ms)
  ✔ structuredReportToHtml (658ms)
  ✔ Apply color presentation state (CSPS) to a color dicom image. (1.9s)
    
  Image SOPs:
  ✔ DICOM SOP: Segmentation Storage. (1.6s)
  ✔ DICOM SOP: Secondary Image Storage. (1.6s)
  ✔ DICOM SOP: RT Dose Storage. (1.6s)
  ✔ DICOM SOP: Digital Mammography X-Ray Image Storage. (1.8s)
  ✔ DICOM SOP: Digital X-Ray Image. (1.9s)
  ✔ DICOM SOP: CT Image. (1.9s)
  ✔ DICOM SOP: Ultrasound Multi-frame Image Storage. (2s)
  ✔ DICOM SOP: Positron Emission Tomography Image Storage. (2.3s)
  ✔ DICOM SOP: MR Image. (2.3s)
  ✔ DICOM SOP: Ultrasound Image Storage. (2.3s)
  ✔ DICOM SOP: Nuclear Medicine Image. (2.3s)
  ✔ DICOM SOP: Computed Radiography. (2.5s)
  