### PR TITLE
fix(dicom-node): export location

### DIFF
--- a/packages/dicom/typescript/package.json
+++ b/packages/dicom/typescript/package.json
@@ -8,7 +8,7 @@
   "exports": {
     ".": {
       "browser": "./dist/bundles/dicom.js",
-      "node": "./dist/bundles/dicom.node.js",
+      "node": "./dist/bundles/dicom-node.js",
       "default": "./dist/bundles/dicom.js"
     }
   },


### PR DESCRIPTION
Update export location to match package installation.

Fix for error:
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'...node_modules\@itk-wasm\dicom\dist\bundles\dicom.node.js'
imported from ...
```