### PR TITLE
fix(readImageDicomFileSeries): await if file objects are passed

### DIFF
--- a/packages/dicom/typescript/src/read-image-dicom-file-series.ts
+++ b/packages/dicom/typescript/src/read-image-dicom-file-series.ts
@@ -34,14 +34,14 @@ async function readImageDicomFileSeries(
     throw new Error('"input-images" option must have a length > 1')
   }
 
-  options.inputImages.forEach(async (value) => {
+  await Promise.all(options.inputImages.map(async (value) => {
     let valueFile = value
     if (value instanceof File) {
       const valueBuffer = await value.arrayBuffer()
       valueFile = { path: value.name, data: new Uint8Array(valueBuffer) }
     }
     inputs.push(valueFile as BinaryFile)
-  })
+  }))
 
   if (options.singleSortedSeries) {
     const taskArgsArray = []

--- a/src/bindgen/typescript/function-module.js
+++ b/src/bindgen/typescript/function-module.js
@@ -279,7 +279,7 @@ function functionModule (srcOutputDir, forNode, interfaceJson, modulePascalCase,
       if (forNode) {
         functionContent += `    options.${camel}.forEach((value) => {\n`
       } else {
-        functionContent += `    options.${camel}.forEach(async (value) => {\n`
+        functionContent += `    await Promise.all(options.${camel}.map(async (value) => {\n`
       }
       if (interfaceJsonTypeToInterfaceType.has(parameter.type)) {
         const interfaceType = interfaceJsonTypeToInterfaceType.get(parameter.type)
@@ -309,7 +309,7 @@ function functionModule (srcOutputDir, forNode, interfaceJson, modulePascalCase,
       } else {
         functionContent += '      args.push(value.toString())\n\n'
       }
-      functionContent += '    })\n'
+      functionContent += forNode ? '    })\n' : '    }))\n';
     } else {
       if (interfaceJsonTypeToInterfaceType.has(parameter.type)) {
         const interfaceType = interfaceJsonTypeToInterfaceType.get(parameter.type)


### PR DESCRIPTION
An await is required if File objects are passed to `readImageDicomFileSeries()`. This is not caught in current cypress tests, since the test calls `readImageDicomFileSeries` with ArrayBuffer objects which doesn't require await since already in memory).

Error details:
```
CLI::ArgumentMismatch: --input-images: 1 required INPUT_BINARY_FILE:FILE missing
```

This fix is related to the following PR for VolView:
https://github.com/Kitware/VolView/pull/385
see: https://github.com/Kitware/VolView/pull/385#discussion_r1286418006