### PR TITLE
fix(read-dicom-tags): tweek typescript options and return types

### DIFF
--- a/packages/dicom/typescript/src/read-dicom-tags-options.ts
+++ b/packages/dicom/typescript/src/read-dicom-tags-options.ts
@@ -1,9 +1,6 @@
-// Generated file. To retain edits, remove this comment.
-
 interface ReadDicomTagsOptions {
   /** A JSON object with a "tags" array of the tags to read. If not provided, all tags are read. Example tag: "0008|103e". */
-  tagsToRead?: Object
-
+  tagsToRead?: { tags: Array<string> }
 }
 
 export default ReadDicomTagsOptions

--- a/packages/dicom/typescript/src/read-dicom-tags-result.ts
+++ b/packages/dicom/typescript/src/read-dicom-tags-result.ts
@@ -1,12 +1,9 @@
-// Generated file. To retain edits, remove this comment.
-
 interface ReadDicomTagsResult {
   /** WebWorker used for computation */
   webWorker: Worker | null
 
   /** Output tags in the file. JSON object an array of [tag, value] arrays. Values are encoded as UTF-8 strings. */
-  tags: Object
-
+  tags: Array<[string, string]>
 }
 
 export default ReadDicomTagsResult


### PR DESCRIPTION
closes #896