### PR TITLE
ci(actions): Fix GitHub actions workflow warnings linked to `Node.js`

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -11,7 +11,7 @@ jobs:
         working-directory: ./examples/node-js
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: 'Free up disk space'
       run: |
@@ -28,7 +28,7 @@ jobs:
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         df -h
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
 
@@ -183,7 +183,7 @@ jobs:
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         df -h
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
 

--- a/.github/workflows/javascript-typescript.yml
+++ b/.github/workflows/javascript-typescript.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: 'Free up disk space'
       run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,11 +6,11 @@ jobs:
     runs-on: ubuntu-20.04
     name: Check and lint PR
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
       - run: npm ci

--- a/.github/workflows/toolchains.yml
+++ b/.github/workflows/toolchains.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: 'Free up disk space'
       run: |

--- a/.github/workflows/wasi.yml
+++ b/.github/workflows/wasi.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: 'Free up disk space'
       run: |
@@ -27,7 +27,7 @@ jobs:
       run: |
         ./src/docker/pull.sh
 
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
 


### PR DESCRIPTION
Fix GitHub actions workflow warnings linked to `Node.js`: bump `actions/checkout` and `actions/setup-node` to `v3`.

Fixes:
```
The following actions uses node12 which is deprecated and will be forced to run on node16:
actions/checkout@v2, actions/setup-node@v2.
For more info:
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

raised for example in:
https://github.com/InsightSoftwareConsortium/itk-wasm/actions/runs/5943988559