### PR TITLE
refactor: move from JsonObject to JsonCompatible interface type

### DIFF
--- a/docs/cxx/interface_types.md
+++ b/docs/cxx/interface_types.md
@@ -9,7 +9,7 @@ itk-wasm execution pipelines support the following [interface types](https://git
 - [Image](../typescript/interface_types/Image)
 - [Mesh](../typescript/interface_types/Mesh)
 - [PolyData](../typescript/interface_types/PolyData)
-- [JsonObject](../typescript/interface_types/JsonObject)
+- [JsonCompatible](../typescript/interface_types/JsonCompatible)
 
 These interfaces types are supported in the [Emscripten interface](../typescript/browser_pipelines), [WASI](https://wasi.dev/) embedding interfaces, and native or virtual [filesystem IO](../introduction/file_formats/index). They are intended to be forward-compatible with the [WebAssembly Component Model](https://github.com/WebAssembly/component-model).
 

--- a/docs/typescript/interface_types/JsonCompatible.md
+++ b/docs/typescript/interface_types/JsonCompatible.md
@@ -1,0 +1,3 @@
+# JsonCompatible
+
+A `JsonCompatible` interface type represents an object, array, null, number, boolean, or nested version of the same that can be parsed from an arbitrary JSON string.

--- a/docs/typescript/interface_types/JsonObject.md
+++ b/docs/typescript/interface_types/JsonObject.md
@@ -1,5 +1,0 @@
-# JsonObject
-
-A `JsonObject` represents a javascript object parsed from an arbitrary JSON string. `JsonObject` is a JavaScript object with the following properties:
-
-- `data`: Of type `Object`, contains the javascript object parsed from a generated JSON text/string.

--- a/docs/typescript/interface_types/index.md
+++ b/docs/typescript/interface_types/index.md
@@ -15,7 +15,7 @@ ImageType.md
 Mesh.md
 MeshType.md
 PolyData.md
-JsonObject.md
+JsonCompatible.md
 ```
 
 These interfaces types are supported in the [Emscripten interface](/api/browser_pipelines), [WASI](https://wasi.dev/) embedding interfaces, and native or virtual [filesystem IO](/introduction/file_formats/index.html). They are intended to be forward-compatible with the [WebAssembly Component Model](https://github.com/WebAssembly/component-model).

--- a/packages/compare-images/python/itkwasm-compare-images-wasi/itkwasm_compare_images_wasi/compare_double_images.py
+++ b/packages/compare-images/python/itkwasm-compare-images-wasi/itkwasm_compare_images_wasi/compare_double_images.py
@@ -56,7 +56,7 @@ def compare_double_images(
         _pipeline = Pipeline(file_resources('itkwasm_compare_images_wasi').joinpath(Path('wasm_modules') / Path('compare-double-images.wasi.wasm')))
 
     pipeline_outputs: List[PipelineOutput] = [
-        PipelineOutput(InterfaceTypes.JsonObject),
+        PipelineOutput(InterfaceTypes.JsonCompatible),
         PipelineOutput(InterfaceTypes.Image),
         PipelineOutput(InterfaceTypes.Image),
     ]
@@ -101,7 +101,7 @@ def compare_double_images(
     outputs = _pipeline.run(args, pipeline_outputs, pipeline_inputs)
 
     result = (
-        outputs[0].data.data,
+        outputs[0].data,
         outputs[1].data,
         outputs[2].data,
     )

--- a/packages/compare-images/typescript/src/compare-double-images-node.ts
+++ b/packages/compare-images/typescript/src/compare-double-images-node.ts
@@ -1,6 +1,5 @@
 import {
   Image,
-  JsonObject,
   InterfaceTypes,
   PipelineOutput,
   PipelineInput,
@@ -27,7 +26,7 @@ async function compareDoubleImagesNode(
 ) : Promise<CompareDoubleImagesNodeResult> {
 
   const desiredOutputs: Array<PipelineOutput> = [
-    { type: InterfaceTypes.JsonObject },
+    { type: InterfaceTypes.JsonCompatible },
     { type: InterfaceTypes.Image },
     { type: InterfaceTypes.Image },
   ]
@@ -94,7 +93,7 @@ async function compareDoubleImagesNode(
   }
 
   const result = {
-    metrics: (outputs[0].data as JsonObject).data as CompareImagesMetric,
+    metrics: outputs[0].data as CompareImagesMetric,
     differenceImage: outputs[1].data as Image,
     differenceUchar2dImage: outputs[2].data as Image,
   }

--- a/packages/compare-images/typescript/src/compare-double-images.ts
+++ b/packages/compare-images/typescript/src/compare-double-images.ts
@@ -1,6 +1,5 @@
 import {
   Image,
-  JsonObject,
   InterfaceTypes,
   PipelineOutput,
   PipelineInput,
@@ -30,7 +29,7 @@ async function compareDoubleImages(
 ) : Promise<CompareDoubleImagesResult> {
 
   const desiredOutputs: Array<PipelineOutput> = [
-    { type: InterfaceTypes.JsonObject },
+    { type: InterfaceTypes.JsonCompatible },
     { type: InterfaceTypes.Image },
     { type: InterfaceTypes.Image },
   ]
@@ -99,7 +98,7 @@ async function compareDoubleImages(
 
   const result = {
     webWorker: usedWebWorker as Worker,
-    metrics: (outputs[0].data as JsonObject).data as CompareImagesMetric,
+    metrics: outputs[0].data as CompareImagesMetric,
     differenceImage: outputs[1].data as Image,
     differenceUchar2dImage: outputs[2].data as Image,
   }

--- a/packages/compress-stringify/python/itkwasm-compress-stringify-emscripten/itkwasm_compress_stringify_emscripten/compress_stringify_async.py
+++ b/packages/compress-stringify/python/itkwasm-compress-stringify-emscripten/itkwasm_compress_stringify_emscripten/compress_stringify_async.py
@@ -1,8 +1,10 @@
+# Generated file. To retain edits, remove this comment.
+
 # Generated file. Do not edit.
 
 from pathlib import Path
 import os
-from typing import Dict, Tuple, Optional, List
+from typing import Dict, Tuple, Optional, List, Any
 
 from .js_package import js_package
 

--- a/packages/compress-stringify/python/itkwasm-compress-stringify-emscripten/itkwasm_compress_stringify_emscripten/parse_string_decompress_async.py
+++ b/packages/compress-stringify/python/itkwasm-compress-stringify-emscripten/itkwasm_compress_stringify_emscripten/parse_string_decompress_async.py
@@ -1,8 +1,10 @@
+# Generated file. To retain edits, remove this comment.
+
 # Generated file. Do not edit.
 
 from pathlib import Path
 import os
-from typing import Dict, Tuple, Optional, List
+from typing import Dict, Tuple, Optional, List, Any
 
 from .js_package import js_package
 

--- a/packages/compress-stringify/python/itkwasm-compress-stringify-wasi/itkwasm_compress_stringify_wasi/compress_stringify.py
+++ b/packages/compress-stringify/python/itkwasm-compress-stringify-wasi/itkwasm_compress_stringify_wasi/compress_stringify.py
@@ -1,8 +1,10 @@
+# Generated file. To retain edits, remove this comment.
+
 # Generated file. Do not edit.
 
 from pathlib import Path, PurePosixPath
 import os
-from typing import Dict, Tuple, Optional, List
+from typing import Dict, Tuple, Optional, List, Any
 
 from importlib_resources import files as file_resources
 

--- a/packages/compress-stringify/python/itkwasm-compress-stringify-wasi/itkwasm_compress_stringify_wasi/parse_string_decompress.py
+++ b/packages/compress-stringify/python/itkwasm-compress-stringify-wasi/itkwasm_compress_stringify_wasi/parse_string_decompress.py
@@ -1,8 +1,10 @@
+# Generated file. To retain edits, remove this comment.
+
 # Generated file. Do not edit.
 
 from pathlib import Path, PurePosixPath
 import os
-from typing import Dict, Tuple, Optional, List
+from typing import Dict, Tuple, Optional, List, Any
 
 from importlib_resources import files as file_resources
 

--- a/packages/compress-stringify/python/itkwasm-compress-stringify/itkwasm_compress_stringify/compress_stringify.py
+++ b/packages/compress-stringify/python/itkwasm-compress-stringify/itkwasm_compress_stringify/compress_stringify.py
@@ -1,7 +1,7 @@
 # Generated file. Do not edit.
 
 import os
-from typing import Dict, Tuple, Optional, List
+from typing import Dict, Tuple, Optional, List, Any
 
 from itkwasm import (
     environment_dispatch,

--- a/packages/compress-stringify/python/itkwasm-compress-stringify/itkwasm_compress_stringify/compress_stringify_async.py
+++ b/packages/compress-stringify/python/itkwasm-compress-stringify/itkwasm_compress_stringify/compress_stringify_async.py
@@ -1,7 +1,7 @@
 # Generated file. Do not edit.
 
 import os
-from typing import Dict, Tuple, Optional, List
+from typing import Dict, Tuple, Optional, List, Any
 
 from itkwasm import (
     environment_dispatch,

--- a/packages/compress-stringify/python/itkwasm-compress-stringify/itkwasm_compress_stringify/parse_string_decompress.py
+++ b/packages/compress-stringify/python/itkwasm-compress-stringify/itkwasm_compress_stringify/parse_string_decompress.py
@@ -1,7 +1,7 @@
 # Generated file. Do not edit.
 
 import os
-from typing import Dict, Tuple, Optional, List
+from typing import Dict, Tuple, Optional, List, Any
 
 from itkwasm import (
     environment_dispatch,

--- a/packages/compress-stringify/python/itkwasm-compress-stringify/itkwasm_compress_stringify/parse_string_decompress_async.py
+++ b/packages/compress-stringify/python/itkwasm-compress-stringify/itkwasm_compress_stringify/parse_string_decompress_async.py
@@ -1,7 +1,7 @@
 # Generated file. Do not edit.
 
 import os
-from typing import Dict, Tuple, Optional, List
+from typing import Dict, Tuple, Optional, List, Any
 
 from itkwasm import (
     environment_dispatch,

--- a/packages/core/python/itkwasm/itkwasm/__init__.py
+++ b/packages/core/python/itkwasm/itkwasm/__init__.py
@@ -11,7 +11,7 @@ from .binary_file import BinaryFile
 from .binary_stream import BinaryStream
 from .text_file import TextFile
 from .text_stream import TextStream
-from .json_object import JsonObject
+from .json_compatible import JsonCompatible
 from .pipeline import Pipeline
 from .pipeline_input import PipelineInput
 from .pipeline_output import PipelineOutput
@@ -38,7 +38,7 @@ __all__ = [
   "BinaryStream",
   "TextFile",
   "TextStream",
-  "JsonObject",
+  "JsonCompatible",
   "FloatTypes",
   "IntTypes",
   "PixelTypes",

--- a/packages/core/python/itkwasm/itkwasm/interface_types.py
+++ b/packages/core/python/itkwasm/itkwasm/interface_types.py
@@ -8,4 +8,4 @@ class InterfaceTypes(Enum):
     Image = 'InterfaceImage'
     Mesh = 'InterfaceMesh'
     PolyData = 'InterfacePolyData'
-    JsonObject = 'InterfaceJsonObject'
+    JsonCompatible = 'InterfaceJsonCompatible'

--- a/packages/core/python/itkwasm/itkwasm/json_compatible.py
+++ b/packages/core/python/itkwasm/itkwasm/json_compatible.py
@@ -1,0 +1,4 @@
+from typing import Dict, Union, List
+
+JsonCompatible = Union[Dict[str, "JsonCompatible"], None, bool, str, int,
+        float, List["JsonCompatible"]]

--- a/packages/core/python/itkwasm/itkwasm/json_object.py
+++ b/packages/core/python/itkwasm/itkwasm/json_object.py
@@ -1,6 +1,0 @@
-from dataclasses import dataclass
-from typing import Dict
-
-@dataclass
-class JsonObject:
-    data: Dict

--- a/packages/core/python/itkwasm/itkwasm/pipeline.py
+++ b/packages/core/python/itkwasm/itkwasm/pipeline.py
@@ -17,7 +17,7 @@ from .binary_file import BinaryFile
 from .image import Image
 from .mesh import Mesh
 from .polydata import PolyData
-from .json_object import JsonObject
+from .json_compatible import JsonCompatible
 from .int_types import IntTypes
 from .float_types import FloatTypes
 from ._to_numpy_array import _to_numpy_array
@@ -289,8 +289,8 @@ class Pipeline:
                     "cellData": f"data:application/vnd.itk.address,0:{cellData_ptr}"
                 }
                 ri.set_input_json(polydata_json, index)
-            elif input_.type == InterfaceTypes.JsonObject:
-                data_array = json.dumps(input_.data.data).encode()
+            elif input_.type == InterfaceTypes.JsonCompatible:
+                data_array = json.dumps(input_.data).encode()
                 array_ptr = ri.set_input_array(data_array, index, 0)
                 data_json = { "size": len(data_array), "data": f"data:application/vnd.itk.address,0:{array_ptr}" }
                 ri.set_input_json(data_json, index)
@@ -424,11 +424,11 @@ class Pipeline:
                         polydata.triangleStrips =  _to_numpy_array(polydata.polyDataType.cellPixelComponentType, bytes([]))
 
                     output_data = PipelineOutput(InterfaceTypes.PolyData, polydata)
-                elif output.type == InterfaceTypes.JsonObject:
+                elif output.type == InterfaceTypes.JsonCompatible:
                     data_ptr = ri.get_output_array_address(0, index, 0)
                     data_size = ri.get_output_array_size(0, index, 0)
                     data_array = ri.wasmtime_lift(data_ptr, data_size)
-                    output_data = PipelineOutput(InterfaceTypes.JsonObject, JsonObject(json.loads(data_array.decode())))
+                    output_data = PipelineOutput(InterfaceTypes.JsonCompatible, json.loads(data_array.decode()))
                 else:
                     raise ValueError(f'Unexpected/not yet supported output.type {output.type}')
 

--- a/packages/core/python/itkwasm/itkwasm/pyodide.py
+++ b/packages/core/python/itkwasm/itkwasm/pyodide.py
@@ -11,7 +11,7 @@ from .text_file import TextFile
 from .text_stream import TextStream
 from .float_types import FloatTypes
 from .int_types import IntTypes
-from .json_object import JsonObject
+from .json_compatible import JsonCompatible
 from ._to_numpy_array import _to_numpy_array
 
 @dataclass
@@ -221,7 +221,5 @@ def to_js(py):
             data = fp.read()
         text_file_dict['data'] = data
         return pyodide.ffi.to_js(text_file_dict, dict_converter=js.Object.fromEntries)
-    elif isinstance(py, JsonObject):
-        return pyodide.ffi.to_js(py.data)
 
     return pyodide.ffi.to_js(py)

--- a/packages/core/python/itkwasm/test/test_pyodide.py
+++ b/packages/core/python/itkwasm/test/test_pyodide.py
@@ -321,11 +321,10 @@ async def test_json_object_conversion(selenium, package_wheel):
     await micropip.install(package_wheel)
 
     from itkwasm.pyodide import to_js, to_py
-    from itkwasm import JsonObject
 
     data = { 'a': 1, 'b': True, 'c': { 'nested': True }}
 
-    data_js = to_js(JsonObject(data))
+    data_js = to_js(data)
     data_py = to_py(data_js)
 
     assert isinstance(data_py, dict)

--- a/packages/dicom/python/itkwasm-dicom-emscripten/itkwasm_dicom_emscripten/read_dicom_encapsulated_pdf_async.py
+++ b/packages/dicom/python/itkwasm-dicom-emscripten/itkwasm_dicom_emscripten/read_dicom_encapsulated_pdf_async.py
@@ -1,3 +1,5 @@
+# Generated file. To retain edits, remove this comment.
+
 # Generated file. Do not edit.
 
 from pathlib import Path

--- a/packages/dicom/python/itkwasm-dicom-emscripten/itkwasm_dicom_emscripten/structured_report_to_html_async.py
+++ b/packages/dicom/python/itkwasm-dicom-emscripten/itkwasm_dicom_emscripten/structured_report_to_html_async.py
@@ -1,3 +1,5 @@
+# Generated file. To retain edits, remove this comment.
+
 # Generated file. Do not edit.
 
 from pathlib import Path

--- a/packages/dicom/python/itkwasm-dicom-emscripten/itkwasm_dicom_emscripten/structured_report_to_text_async.py
+++ b/packages/dicom/python/itkwasm-dicom-emscripten/itkwasm_dicom_emscripten/structured_report_to_text_async.py
@@ -1,3 +1,5 @@
+# Generated file. To retain edits, remove this comment.
+
 # Generated file. Do not edit.
 
 from pathlib import Path

--- a/packages/dicom/python/itkwasm-dicom-wasi/itkwasm_dicom_wasi/apply_presentation_state_to_image.py
+++ b/packages/dicom/python/itkwasm-dicom-wasi/itkwasm_dicom_wasi/apply_presentation_state_to_image.py
@@ -58,7 +58,7 @@ def apply_presentation_state_to_image(
         _pipeline = Pipeline(file_resources('itkwasm_dicom_wasi').joinpath(Path('wasm_modules') / Path('apply-presentation-state-to-image.wasi.wasm')))
 
     pipeline_outputs: List[PipelineOutput] = [
-        PipelineOutput(InterfaceTypes.JsonObject),
+        PipelineOutput(InterfaceTypes.JsonCompatible),
         PipelineOutput(InterfaceTypes.Image),
     ]
 
@@ -100,7 +100,7 @@ def apply_presentation_state_to_image(
     outputs = _pipeline.run(args, pipeline_outputs, pipeline_inputs)
 
     result = (
-        outputs[0].data.data,
+        outputs[0].data,
         outputs[1].data,
     )
     return result

--- a/packages/dicom/python/itkwasm-dicom-wasi/itkwasm_dicom_wasi/read_dicom_encapsulated_pdf.py
+++ b/packages/dicom/python/itkwasm-dicom-wasi/itkwasm_dicom_wasi/read_dicom_encapsulated_pdf.py
@@ -1,3 +1,5 @@
+# Generated file. To retain edits, remove this comment.
+
 # Generated file. Do not edit.
 
 from pathlib import Path, PurePosixPath

--- a/packages/dicom/python/itkwasm-dicom-wasi/itkwasm_dicom_wasi/read_image_dicom_file_series.py
+++ b/packages/dicom/python/itkwasm-dicom-wasi/itkwasm_dicom_wasi/read_image_dicom_file_series.py
@@ -39,7 +39,7 @@ def read_image_dicom_file_series(
 
     pipeline_outputs: List[PipelineOutput] = [
         PipelineOutput(InterfaceTypes.Image),
-        PipelineOutput(InterfaceTypes.JsonObject),
+        PipelineOutput(InterfaceTypes.JsonCompatible),
     ]
 
     pipeline_inputs: List[PipelineInput] = [
@@ -68,7 +68,7 @@ def read_image_dicom_file_series(
 
     result = (
         outputs[0].data,
-        outputs[1].data.data,
+        outputs[1].data,
     )
     return result
 

--- a/packages/dicom/python/itkwasm-dicom-wasi/itkwasm_dicom_wasi/structured_report_to_html.py
+++ b/packages/dicom/python/itkwasm-dicom-wasi/itkwasm_dicom_wasi/structured_report_to_html.py
@@ -1,3 +1,5 @@
+# Generated file. To retain edits, remove this comment.
+
 # Generated file. Do not edit.
 
 from pathlib import Path, PurePosixPath

--- a/packages/dicom/python/itkwasm-dicom-wasi/itkwasm_dicom_wasi/structured_report_to_text.py
+++ b/packages/dicom/python/itkwasm-dicom-wasi/itkwasm_dicom_wasi/structured_report_to_text.py
@@ -1,3 +1,5 @@
+# Generated file. To retain edits, remove this comment.
+
 # Generated file. Do not edit.
 
 from pathlib import Path, PurePosixPath

--- a/packages/dicom/typescript/package.json
+++ b/packages/dicom/typescript/package.json
@@ -38,7 +38,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "itk-wasm": "^1.0.0-b.119"
+    "itk-wasm": "^1.0.0-b.128"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",
@@ -59,7 +59,7 @@
     "start-server-and-test": "^2.0.0",
     "supports-color": "^9.3.1",
     "tslib": "^2.5.2",
-    "typescript": "^5.0.4",
+    "typescript": "^5.1.6",
     "vite": "^4.1.5",
     "vite-plugin-static-copy": "^0.14.0"
   },

--- a/packages/dicom/typescript/src/apply-presentation-state-to-image-node-result.ts
+++ b/packages/dicom/typescript/src/apply-presentation-state-to-image-node-result.ts
@@ -1,10 +1,10 @@
 // Generated file. To retain edits, remove this comment.
 
-import { Image } from 'itk-wasm'
+import { JsonCompatible, Image } from 'itk-wasm'
 
 interface ApplyPresentationStateToImageNodeResult {
   /** Output overlay information */
-  presentationStateOutStream: Object
+  presentationStateOutStream: JsonCompatible
 
   /** Output image */
   outputImage: Image

--- a/packages/dicom/typescript/src/apply-presentation-state-to-image-node.ts
+++ b/packages/dicom/typescript/src/apply-presentation-state-to-image-node.ts
@@ -1,7 +1,7 @@
 // Generated file. To retain edits, remove this comment.
 
 import {
-  JsonObject,
+  JsonCompatible,
   Image,
   InterfaceTypes,
   PipelineOutput,
@@ -33,7 +33,7 @@ async function applyPresentationStateToImageNode(
   const mountDirs: Set<string> = new Set()
 
   const desiredOutputs: Array<PipelineOutput> = [
-    { type: InterfaceTypes.JsonObject },
+    { type: InterfaceTypes.JsonCompatible },
     { type: InterfaceTypes.Image },
   ]
 
@@ -89,7 +89,7 @@ async function applyPresentationStateToImageNode(
   }
 
   const result = {
-    presentationStateOutStream: (outputs[0].data as JsonObject).data,
+    presentationStateOutStream: outputs[0].data as JsonCompatible,
     outputImage: outputs[1].data as Image,
   }
   return result

--- a/packages/dicom/typescript/src/apply-presentation-state-to-image-result.ts
+++ b/packages/dicom/typescript/src/apply-presentation-state-to-image-result.ts
@@ -1,13 +1,13 @@
 // Generated file. To retain edits, remove this comment.
 
-import { Image } from 'itk-wasm'
+import { JsonCompatible, Image } from 'itk-wasm'
 
 interface ApplyPresentationStateToImageResult {
   /** WebWorker used for computation */
   webWorker: Worker | null
 
   /** Output overlay information */
-  presentationStateOutStream: Object
+  presentationStateOutStream: JsonCompatible
 
   /** Output image */
   outputImage: Image

--- a/packages/dicom/typescript/src/apply-presentation-state-to-image.ts
+++ b/packages/dicom/typescript/src/apply-presentation-state-to-image.ts
@@ -2,7 +2,7 @@
 
 import {
   BinaryFile,
-  JsonObject,
+  JsonCompatible,
   Image,
   InterfaceTypes,
   PipelineOutput,
@@ -34,7 +34,7 @@ async function applyPresentationStateToImage(
 ) : Promise<ApplyPresentationStateToImageResult> {
 
   const desiredOutputs: Array<PipelineOutput> = [
-    { type: InterfaceTypes.JsonObject },
+    { type: InterfaceTypes.JsonCompatible },
     { type: InterfaceTypes.Image },
   ]
 
@@ -102,7 +102,7 @@ async function applyPresentationStateToImage(
 
   const result = {
     webWorker: usedWebWorker as Worker,
-    presentationStateOutStream: (outputs[0].data as JsonObject).data,
+    presentationStateOutStream: outputs[0].data as JsonCompatible,
     outputImage: outputs[1].data as Image,
   }
   return result

--- a/packages/dicom/typescript/src/read-dicom-tags-node-result.ts
+++ b/packages/dicom/typescript/src/read-dicom-tags-node-result.ts
@@ -1,8 +1,6 @@
-// Generated file. To retain edits, remove this comment.
-
 interface ReadDicomTagsNodeResult {
   /** Output tags in the file. JSON object an array of [tag, value] arrays. Values are encoded as UTF-8 strings. */
-  tags: Object
+  tags: [string, string][]
 
 }
 

--- a/packages/dicom/typescript/src/read-dicom-tags-node.ts
+++ b/packages/dicom/typescript/src/read-dicom-tags-node.ts
@@ -1,7 +1,7 @@
 // Generated file. To retain edits, remove this comment.
 
 import {
-  JsonObject,
+  JsonCompatible,
   InterfaceTypes,
   PipelineOutput,
   PipelineInput,
@@ -30,7 +30,7 @@ async function readDicomTagsNode(
   const mountDirs: Set<string> = new Set()
 
   const desiredOutputs: Array<PipelineOutput> = [
-    { type: InterfaceTypes.JsonObject },
+    { type: InterfaceTypes.JsonCompatible },
   ]
 
   mountDirs.add(path.dirname(dicomFile as string))
@@ -50,7 +50,7 @@ async function readDicomTagsNode(
   args.push('--memory-io')
   if (typeof options.tagsToRead !== "undefined") {
     const inputCountString = inputs.length.toString()
-    inputs.push({ type: InterfaceTypes.JsonObject, data: options.tagsToRead as JsonObject })
+    inputs.push({ type: InterfaceTypes.JsonCompatible, data: options.tagsToRead as JsonCompatible })
     args.push('--tags-to-read', inputCountString)
 
   }
@@ -67,7 +67,7 @@ async function readDicomTagsNode(
   }
 
   const result = {
-    tags: (outputs[0].data as JsonObject).data,
+    tags: outputs[0].data as JsonCompatible,
   }
   return result
 }

--- a/packages/dicom/typescript/src/read-dicom-tags.ts
+++ b/packages/dicom/typescript/src/read-dicom-tags.ts
@@ -1,8 +1,5 @@
-// Generated file. To retain edits, remove this comment.
-
 import {
   BinaryFile,
-  JsonObject,
   InterfaceTypes,
   PipelineOutput,
   PipelineInput,
@@ -31,7 +28,7 @@ async function readDicomTags(
 ) : Promise<ReadDicomTagsResult> {
 
   const desiredOutputs: Array<PipelineOutput> = [
-    { type: InterfaceTypes.JsonObject },
+    { type: InterfaceTypes.JsonCompatible },
   ]
 
   let dicomFileFile = dicomFile
@@ -56,7 +53,7 @@ async function readDicomTags(
   args.push('--memory-io')
   if (typeof options.tagsToRead !== "undefined") {
     const inputCountString = inputs.length.toString()
-    inputs.push({ type: InterfaceTypes.JsonObject, data: options.tagsToRead as JsonObject })
+    inputs.push({ type: InterfaceTypes.JsonCompatible, data: options.tagsToRead })
     args.push('--tags-to-read', inputCountString)
 
   }
@@ -75,7 +72,7 @@ async function readDicomTags(
 
   const result = {
     webWorker: usedWebWorker as Worker,
-    tags: (outputs[0].data as JsonObject).data,
+    tags: outputs[0].data as [string, string][],
   }
   return result
 }

--- a/packages/dicom/typescript/src/read-image-dicom-file-series-node-result.ts
+++ b/packages/dicom/typescript/src/read-image-dicom-file-series-node-result.ts
@@ -1,13 +1,13 @@
 // Generated file. To retain edits, remove this comment.
 
-import { Image } from 'itk-wasm'
+import { Image, JsonCompatible } from 'itk-wasm'
 
 interface ReadImageDicomFileSeriesNodeResult {
   /** Output image volume */
   outputImage: Image
 
   /** Output sorted filenames */
-  sortedFilenames: Object
+  sortedFilenames: JsonCompatible
 
 }
 

--- a/packages/dicom/typescript/src/read-image-dicom-file-series-node.ts
+++ b/packages/dicom/typescript/src/read-image-dicom-file-series-node.ts
@@ -2,7 +2,7 @@
 
 import {
   Image,
-  JsonObject,
+  JsonCompatible,
   InterfaceTypes,
   PipelineOutput,
   PipelineInput,
@@ -30,7 +30,7 @@ async function readImageDicomFileSeriesNode(
 
   const desiredOutputs: Array<PipelineOutput> = [
     { type: InterfaceTypes.Image },
-    { type: InterfaceTypes.JsonObject },
+    { type: InterfaceTypes.JsonCompatible },
   ]
 
   const inputs: Array<PipelineInput> = [
@@ -77,7 +77,7 @@ async function readImageDicomFileSeriesNode(
 
   const result = {
     outputImage: outputs[0].data as Image,
-    sortedFilenames: (outputs[1].data as JsonObject).data,
+    sortedFilenames: outputs[1].data as JsonCompatible,
   }
   return result
 }

--- a/packages/dicom/typescript/src/read-image-dicom-file-series-worker-function.ts
+++ b/packages/dicom/typescript/src/read-image-dicom-file-series-worker-function.ts
@@ -5,7 +5,6 @@ import {
   PipelineInput,
   InterfaceTypes,
   Image,
-  JsonObject,
 } from 'itk-wasm'
 
 import { getPipelinesBaseUrl } from './pipelines-base-url.js'
@@ -25,7 +24,7 @@ async function readImageDicomFileSeriesWorkerFunction(
 
   const desiredOutputs: Array<PipelineOutput> = [
     { type: InterfaceTypes.Image },
-    { type: InterfaceTypes.JsonObject },
+    { type: InterfaceTypes.JsonCompatible },
   ]
 
   const inputs: Array<PipelineInput> = [
@@ -66,7 +65,7 @@ async function readImageDicomFileSeriesWorkerFunction(
   const result = {
     webWorker: usedWebWorker as Worker,
     outputImage: outputs[0].data as Image,
-    sortedFilenames: ((outputs[1].data as JsonObject).data as string[]),
+    sortedFilenames: outputs[1].data as string[],
   }
   return result
 }

--- a/packages/dicom/typescript/test/browser/demo-app/index.html
+++ b/packages/dicom/typescript/test/browser/demo-app/index.html
@@ -54,6 +54,7 @@
 
   <h2>@itk-wasm/dicom<img src="./javascript-logo.svg" alt="JavaScript logo" class="language-logo"/><img src="./typescript-logo.svg" alt="TypeScript logo" class="language-logo"/></h2>
   <i>Read files and images related to DICOM file format.</i>
+  <h3>👨‍💻 Live API Demo ✨</h3>
   <br /><br />
 
   <sl-tab-group>
@@ -79,7 +80,7 @@
       <sl-checkbox name="color-output">colorOutput - <i>output image as RGB (default: false)</i></sl-checkbox>
 <br /><br />
       <sl-input name="config-file" type="text" label="configFile" help-text="filename: string. Process using settings from configuration file"></sl-input>
-      <sl-input name="frame" type="number" value="1" label="frame" help-text="frame: integer. Process using image frame f (default: 1)"></sl-input>
+      <sl-input name="frame" type="number" value="1" step="1" label="frame" help-text="frame: integer. Process using image frame f (default: 1)"></sl-input>
 <br />
       <sl-checkbox name="no-presentation-state-output">noPresentationStateOutput - <i>Do not get presentation state information in text stream.</i></sl-checkbox>
 <br /><br />

--- a/src/bindgen/interface-json-type-to-interface-type.js
+++ b/src/bindgen/interface-json-type-to-interface-type.js
@@ -17,8 +17,8 @@ const interfaceJsonTypeToInterfaceType = new Map([
   ['OUTPUT_MESH', 'Mesh'],
   ['INPUT_POLYDATA', 'PolyData'],
   ['OUTPUT_POLYDATA', 'PolyData'],
-  ['INPUT_JSON', 'JsonObject'],
-  ['OUTPUT_JSON', 'JsonObject'],
+  ['INPUT_JSON', 'JsonCompatible'],
+  ['OUTPUT_JSON', 'JsonCompatible'],
 ])
 
 export default interfaceJsonTypeToInterfaceType

--- a/src/bindgen/python/function-module-imports.js
+++ b/src/bindgen/python/function-module-imports.js
@@ -8,7 +8,7 @@ function functionModuleImports(interfaceJson) {
     interfaceJson[pipelineComponent].forEach((value) => {
       if (interfaceJsonTypeToInterfaceType.has(value.type)) {
         const interfaceType = interfaceJsonTypeToInterfaceType.get(value.type)
-        if (interfaceType !== 'JsonObject') {
+        if (interfaceType !== 'JsonCompatible') {
           usedInterfaceTypes.add(interfaceType)
         }
       }

--- a/src/bindgen/python/wasi/wasi-function-module.js
+++ b/src/bindgen/python/wasi/wasi-function-module.js
@@ -130,7 +130,7 @@ from itkwasm import (
           args += `            pipeline_inputs.append(PipelineInput(InterfaceTypes.${interfaceType}, ${interfaceType}(value)))\n`
           args += `            args.append(input_count_spring)\n`
         } else {
-          // Image, Mesh, PolyData, JsonObject
+          // Image, Mesh, PolyData, JsonCompatible
           args += `            input_count_string = str(len(pipeline_inputs))\n`
           args += `            pipeline_inputs.append(PipelineInput(InterfaceTypes.${interfaceType}, value))\n`
           args += `            args.append(input_count_string)\n`
@@ -155,7 +155,7 @@ from itkwasm import (
           args += `        args.append('--${parameter.name}')\n`
           args += `        args.append(input_count_string)\n`
         } else {
-          // Image, Mesh, PolyData, JsonObject
+          // Image, Mesh, PolyData, JsonCompatible
           args += `        input_count_string = str(len(pipeline_inputs))\n`
           args += `        pipeline_inputs.append(PipelineInput(InterfaceTypes.${interfaceType}, ${snake}))\n`
           args += `        args.append('--${parameter.name}')\n`

--- a/src/bindgen/typescript/interface-json-type-to-typescript-type.js
+++ b/src/bindgen/typescript/interface-json-type-to-typescript-type.js
@@ -25,8 +25,8 @@ const interfaceJsonTypeToTypeScriptType = new Map([
   ['UINT:UINT', 'number'],
   ['FLOAT', 'number'],
   ['FLOAT:FLOAT', 'number'],
-  ['INPUT_JSON', 'any'],
-  ['OUTPUT_JSON', 'any'],
+  ['INPUT_JSON', 'JsonCompatible'],
+  ['OUTPUT_JSON', 'JsonCompatible'],
 ])
 
 export default interfaceJsonTypeToTypeScriptType

--- a/src/bindgen/typescript/results-module.js
+++ b/src/bindgen/typescript/results-module.js
@@ -28,6 +28,9 @@ function resultsModule (srcOutputDir, interfaceJson, forNode, modulePascalCase, 
     }
     resultContent += `  /** ${output.description} */\n`
     const outputType = interfaceJsonTypeToTypeScriptType.get(output.type)
+    if (outputType === 'JsonCompatible') {
+      resultsImportTypes.add('JsonCompatible')
+    }
     if (forNode && outputType.includes('File')) {
       resultContent += `  ${camelCase(output.name)}: string\n\n`
     } else {

--- a/src/core/InterfaceTypes.ts
+++ b/src/core/InterfaceTypes.ts
@@ -7,7 +7,7 @@ const InterfaceTypes = {
   Image: 'InterfaceImage',
   Mesh: 'InterfaceMesh',
   PolyData: 'InterfacePolyData',
-  JsonObject: 'InterfaceJsonObject'
+  JsonCompatible: 'InterfaceJsonCompatible'
 } as const
 
 export default InterfaceTypes

--- a/src/core/JsonCompatible.ts
+++ b/src/core/JsonCompatible.ts
@@ -1,8 +1,9 @@
 type JsonCompatible =
+    | null
     | string
     | number
     | boolean
-    | { [x: string]: JsonCompatible }
+    | { [key: string]: JsonCompatible }
     | JsonCompatible[]
 
 export default JsonCompatible

--- a/src/core/JsonObject.ts
+++ b/src/core/JsonObject.ts
@@ -1,7 +1,0 @@
-import JsonCompatible from './JsonCompatible.js'
-
-interface JsonObject {
-  data: JsonCompatible
-}
-
-export default JsonObject

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -9,7 +9,6 @@ export { default as TextStream } from './TextStream.js'
 export { default as BinaryStream } from './BinaryStream.js'
 export { default as TextFile } from './TextFile.js'
 export { default as BinaryFile } from './BinaryFile.js'
-export { default as JsonObject } from './JsonObject.js'
 export { default as JsonCompatible } from './JsonCompatible.js'
 
 export { default as TypedArray } from './TypedArray.js'

--- a/src/io/deprecated/ReadDICOMTagsResult.ts
+++ b/src/io/deprecated/ReadDICOMTagsResult.ts
@@ -1,7 +1,7 @@
 interface ReadDICOMTagsResult {
   webWorker: Worker
 
-  tags: Map<string, string>
+  tags: Array<[string, string]>
 }
 
 export default ReadDICOMTagsResult

--- a/src/pipeline/PipelineInput.ts
+++ b/src/pipeline/PipelineInput.ts
@@ -7,7 +7,7 @@ import BinaryStream from '../core/BinaryStream.js'
 import Image from '../core/Image.js'
 import Mesh from '../core/Mesh.js'
 import PolyData from '../core/PolyData.js'
-import JsonObject from '../core/JsonObject.js'
+import JsonCompatible from '../core/JsonCompatible.js'
 
 interface PipelineInput {
   // Backwards compatibility with IOTypes -- remove?
@@ -18,7 +18,7 @@ interface PipelineInput {
   data:
   | string
   | Uint8Array
-  | JsonObject
+  | JsonCompatible
   | TextStream
   | BinaryStream
   | TextFile

--- a/src/pipeline/PipelineOutput.ts
+++ b/src/pipeline/PipelineOutput.ts
@@ -7,7 +7,7 @@ import BinaryStream from '../core/BinaryStream.js'
 import Image from '../core/Image.js'
 import Mesh from '../core/Mesh.js'
 import PolyData from '../core/PolyData.js'
-import JsonObject from '../core/JsonObject.js'
+import JsonCompatible from '../core/JsonCompatible.js'
 
 interface PipelineOutput {
   path?: string
@@ -17,7 +17,7 @@ interface PipelineOutput {
   data?:
   | string
   | Uint8Array
-  | JsonObject
+  | JsonCompatible
   | TextStream
   | BinaryStream
   | TextFile

--- a/src/pipeline/internal/runPipelineEmscripten.ts
+++ b/src/pipeline/internal/runPipelineEmscripten.ts
@@ -93,9 +93,9 @@ function runPipelineEmscripten (pipelineModule: PipelineEmscriptenModule, args: 
           setPipelineModuleInputJSON(pipelineModule, dataJSON, index)
           break
         }
-        case InterfaceTypes.JsonObject:
+        case InterfaceTypes.JsonCompatible:
         {
-          const dataArray = encoder.encode(JSON.stringify(input.data))
+          const dataArray = encoder.encode(JSON.stringify(input))
           const arrayPtr = setPipelineModuleInputArray(pipelineModule, dataArray, index, 0)
           const dataJSON = { size: dataArray.buffer.byteLength, data: `data:application/vnd.itk.address,0:${arrayPtr}` }
           setPipelineModuleInputJSON(pipelineModule, dataJSON, index)
@@ -325,12 +325,12 @@ function runPipelineEmscripten (pipelineModule: PipelineEmscriptenModule, args: 
           outputData = { data: decoder.decode(dataArrayView) }
           break
         }
-        case InterfaceTypes.JsonObject:
+        case InterfaceTypes.JsonCompatible:
         {
           const dataPtr = pipelineModule.ccall('itk_wasm_output_array_address', 'number', ['number', 'number', 'number'], [0, index, 0])
           const dataSize = pipelineModule.ccall('itk_wasm_output_array_size', 'number', ['number', 'number', 'number'], [0, index, 0])
           const dataArrayView = new Uint8Array(pipelineModule.HEAPU8.buffer, dataPtr, dataSize)
-          outputData = { data: JSON.parse(decoder.decode(dataArrayView)) }
+          outputData = JSON.parse(decoder.decode(dataArrayView))
           break
         }
         case InterfaceTypes.BinaryStream:

--- a/test/node/pipeline/runPipelineNodeTest.js
+++ b/test/node/pipeline/runPipelineNodeTest.js
@@ -64,15 +64,15 @@ test('runPipelineNode uses input and output json data via memory io', (t) => {
     '0'
   ]
   const desiredOutputs = [
-    { type: InterfaceTypes.JsonObject }
+    { type: InterfaceTypes.JsonCompatible }
   ]
   const jsonObject = { key1: 'text', key2: 8 }
   const inputs = [
-    { type: InterfaceTypes.JsonObject, data: jsonObject }
+    { type: InterfaceTypes.JsonCompatible, data: jsonObject }
   ]
   return runPipelineNode(pipelinePath, args, desiredOutputs, inputs)
     .then(function ({ outputs }) {
-      t.is(outputs[0].type, InterfaceTypes.JsonObject)
+      t.is(outputs[0].type, InterfaceTypes.JsonCompatible)
       t.deepEqual(outputs[0].data.data, jsonObject)
     })
 })


### PR DESCRIPTION
1. Indicate not just Object, but boolean, string, etc. can be used
2. Remove extra object and `data` on the interface type.