### PR TITLE
build: add typescript types to "exports" in package.json

### DIFF
--- a/packages/compare-images/typescript/package.json
+++ b/packages/compare-images/typescript/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/src/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/src/index.d.ts",
       "browser": "./dist/bundles/compare-images.js",
       "node": "./dist/bundles/compare-images.node.js",
       "default": "./dist/bundles/compare-images.js"

--- a/packages/compress-stringify/typescript/package.json
+++ b/packages/compress-stringify/typescript/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/src/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/src/index.d.ts",
       "browser": "./dist/bundles/compress-stringify.js",
       "node": "./dist/bundles/compress-stringify.node.js",
       "default": "./dist/bundles/compress-stringify.js"

--- a/packages/dicom/typescript/package.json
+++ b/packages/dicom/typescript/package.json
@@ -7,6 +7,7 @@
   "types": "./dist/src/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/src/index.d.ts",
       "browser": "./dist/bundles/dicom.js",
       "node": "./dist/bundles/dicom.node.js",
       "default": "./dist/bundles/dicom.js"

--- a/src/bindgen/typescript/resources/template.package.json
+++ b/src/bindgen/typescript/resources/template.package.json
@@ -7,6 +7,7 @@
   "types": "./dist/src/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/src/index.d.ts",
       "browser": "./dist/bundles/bundle-name.js",
       "node": "./dist/bundles/bundle-name-node.js",
       "default": "./dist/bundles/bundle-name.js"


### PR DESCRIPTION
"types" outside exports is listed as a "fallback" per

https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing