### PR TITLE
fix(dicom): typo in node export

### DIFF
--- a/packages/dicom/typescript/package.json
+++ b/packages/dicom/typescript/package.json
@@ -9,7 +9,7 @@
     ".": {
       "types": "./dist/src/index.d.ts",
       "browser": "./dist/bundles/dicom.js",
-      "node": "./dist/bundles/dicom.node.js",
+      "node": "./dist/bundles/dicom-node.js",
       "default": "./dist/bundles/dicom.js"
     }
   },


### PR DESCRIPTION
The output file is `dicom-node.js` instead of `dicom.node.js`.