### PR TITLE
ci: make node.js versions consistent across workflow file jobs

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -30,7 +30,7 @@ jobs:
 
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '18'
 
     - name: Install
       run: |
@@ -185,7 +185,7 @@ jobs:
 
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '18'
 
     - name: Install
       run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: '18'
       - run: npm ci
       - name: Lint commits
         run: npx commitlint --from=${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/wasi.yml
+++ b/.github/workflows/wasi.yml
@@ -29,7 +29,7 @@ jobs:
 
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '18'
 
     - name: Install packages
       run: |


### PR DESCRIPTION
Make Node.js versions consistent across workflow file jobs: use version 18.