### PR TITLE
build(cmake): set `download_extract_timestamp` to `true`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,12 @@ project(WebAssemblyInterface)
 
 set(CMAKE_CXX_STANDARD 17)
 
+if(${CMAKE_VERSION} VERSION_LESS 3.24)
+  set(download_extract_timestamp_flag)
+else()
+  set(download_extract_timestamp_flag DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
+endif()
+
 set(WebAssemblyInterface_LIBRARIES WebAssemblyInterface)
 
 option(BUILD_ITK_WASM_IO_MODULES "Build the itk-wasm ImageIO's and MeshIO's" OFF)


### PR DESCRIPTION
Set `DOWNLOAD_EXTRACT_TIMESTAMP` to `TRUE`: the timestamps of the extracted files will reflect the timestamps in the archive.

Fixes:
```
CMake Warning (dev) at D:/a/_temp/-2103337693/cmake-3.24.2-windows-x86_64/share/cmake-3.24/Modules/ExternalProject.cmake:3074 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
```

raised for exmaple in:
https://open.cdash.org/build/8983547/configure

Related documentation:
https://cmake.org/cmake/help/latest/module/ExternalProject.html?highlight=download_extract_timestamp https://cmake.org/cmake/help/latest/policy/CMP0135.html