### PR TITLE
docs: add contributing documentation file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please see [our contributing documentation](docs/development/hacking_itk_wasm.md#contributing) for more information.


### PR DESCRIPTION
Add contributing documentation file: cross-reference the contributing
section of the `hacking_itk_wasm.md` file.