### PR TITLE
fix(bindgen): only skip output index for files with node

### DIFF
--- a/src/bindgen/typescript/function-module.js
+++ b/src/bindgen/typescript/function-module.js
@@ -323,7 +323,7 @@ function functionModule (srcOutputDir, forNode, interfaceJson, modulePascalCase,
         }
       }
       functionContent += '\n'
-      if (!interfaceType.includes('File')) {
+      if (!(forNode && interfaceType.includes('File'))) {
         outputCount++
       }
     } else {
@@ -460,7 +460,7 @@ function functionModule (srcOutputDir, forNode, interfaceJson, modulePascalCase,
         functionContent += `    ${camel}: outputs[${outputIndex}].data as ${interfaceType},\n`
       }
     }
-    if (!interfaceType.includes('File')) {
+    if (!(forNode && interfaceType.includes('File'))) {
       outputCount++
     }
   })


### PR DESCRIPTION
In the browser, they are not mounted. Follow-up to 3ff0d7385b3812f72b03720dc2a4dd32e5835bc4.