### PR TITLE
fix(createWebWorkerPromise): revoke revokeObjectURL

### DIFF
--- a/src/core/createWebWorkerPromise.ts
+++ b/src/core/createWebWorkerPromise.ts
@@ -43,7 +43,6 @@ async function createWebWorkerPromise (existingWorker: Worker | null, pipelineWo
       const response = await axios.get(`${webWorkerString}/bundles/pipeline.${min}worker.js`, { responseType: 'blob' })
       const workerObjectUrl = URL.createObjectURL(response.data as Blob)
       worker = new Worker(workerObjectUrl, { type: 'module' })
-      URL.revokeObjectURL(workerObjectUrl)
     } else {
       worker = new Worker(`${webWorkerString}/bundles/pipeline.${min}worker.js`, { type: 'module' })
     }
@@ -57,7 +56,6 @@ async function createWebWorkerPromise (existingWorker: Worker | null, pipelineWo
       const response = await axios.get(workerUrl, { responseType: 'blob' })
       const workerObjectUrl = URL.createObjectURL(response.data as Blob)
       worker = new Worker(workerObjectUrl, { type: 'module' })
-      URL.revokeObjectURL(workerObjectUrl)
     } else {
       worker = new Worker(workerUrl, { type: 'module' })
     }


### PR DESCRIPTION
Addresses:

  blob:http://localhost:5173/e8a4572c-e8e3-4174-916d-f90930010413	(failed)net::ERR_FILE_NOT_FOUND	script	Other

with local development of derived apps.