### PR TITLE
feat: provide createWebWorker

### DIFF
--- a/packages/core/typescript/itk-wasm/cypress/e2e/pipeline/run-pipeline.cy.ts
+++ b/packages/core/typescript/itk-wasm/cypress/e2e/pipeline/run-pipeline.cy.ts
@@ -47,7 +47,7 @@ describe('runPipeline', () => {
     })
   })
 
-  it('fetches Wasm files from a custom pipelineWorkerUrl string', () => {
+  it('fetches the pipeline web worker from a custom pipelineWorkerUrl string', () => {
     cy.window().then(async (win) => {
       const itk = win.itk
       const pipelineWorkerUrl = new URL('/itk-wasm-pipeline.worker.js', demoServer).href
@@ -57,6 +57,20 @@ describe('runPipeline', () => {
       const inputs = null
       const stdoutStderrPath = 'stdout-stderr-test'
       const { webWorker, returnValue, stdout, stderr } = await itk.runPipeline(null, stdoutStderrPath, args, outputs, inputs, { pipelineWorkerUrl })
+    })
+  })
+
+  it('uses a web worker created explicitly beforehand', () => {
+    cy.window().then(async (win) => {
+      const itk = win.itk
+      const pipelineWorkerUrl = new URL('/itk-wasm-pipeline.worker.js', demoServer).href
+      const webWorker = await itk.createWebWorker(pipelineWorkerUrl)
+
+      const args = []
+      const outputs = null
+      const inputs = null
+      const stdoutStderrPath = 'stdout-stderr-test'
+      const { returnValue, stdout, stderr } = await itk.runPipeline(webWorker, stdoutStderrPath, args, outputs, inputs)
     })
   })
 

--- a/packages/core/typescript/itk-wasm/src/pipeline/create-web-worker.ts
+++ b/packages/core/typescript/itk-wasm/src/pipeline/create-web-worker.ts
@@ -1,0 +1,24 @@
+import axios from 'axios'
+
+async function createWebWorker (pipelineWorkerUrl?: string | null): Promise<Worker> {
+  const workerUrl = pipelineWorkerUrl
+  let worker = null
+  if (workerUrl === null) {
+    // Use the version built with the bundler
+    //
+    // Bundlers, e.g. WebPack, Vite, Rollup, see these paths at build time
+    worker = new Worker(new URL('./web-workers/itk-wasm-pipeline.worker.js', import.meta.url), { type: 'module' })
+  } else {
+    if ((workerUrl as string).startsWith('http')) {
+      const response = await axios.get((workerUrl as string), { responseType: 'blob' })
+      const workerObjectUrl = URL.createObjectURL(response.data as Blob)
+      worker = new Worker(workerObjectUrl, { type: 'module' })
+    } else {
+      worker = new Worker((workerUrl as string), { type: 'module' })
+    }
+  }
+
+  return worker
+}
+
+export default createWebWorker

--- a/packages/core/typescript/itk-wasm/src/pipeline/index.ts
+++ b/packages/core/typescript/itk-wasm/src/pipeline/index.ts
@@ -1,6 +1,7 @@
 // itk-wasm Browser pipeline functions
 
 export { default as runPipeline } from './run-pipeline.js'
+export { default as createWebWorker } from './create-web-worker.js'
 
 export * from './pipeline-worker-url.js'
 export * from './pipelines-base-url.js'


### PR DESCRIPTION
So compatible web workers can be created explicitly when desired.