### PR TITLE
fix(loadPipelineModule): load pipeline once

### DIFF
--- a/packages/core/typescript/itk-wasm/src/pipeline/web-workers/load-pipeline-module.ts
+++ b/packages/core/typescript/itk-wasm/src/pipeline/web-workers/load-pipeline-module.ts
@@ -1,8 +1,8 @@
 import loadEmscriptenModule from '../internal/load-emscripten-module-web-worker.js'
 import PipelineEmscriptenModule from '../pipeline-emscripten-module.js'
 
-// To cache loaded pipeline modules
-const pipelineToModule: Map<string, PipelineEmscriptenModule> = new Map()
+// To cache loaded pipeline modules wrapped in a Promise
+const pipelineToModule: Map<string, Promise<PipelineEmscriptenModule>> = new Map()
 
 async function loadPipelineModule (pipelinePath: string | object, baseUrl: string): Promise<PipelineEmscriptenModule> {
   let moduleRelativePathOrURL: string | URL = pipelinePath as string
@@ -13,10 +13,10 @@ async function loadPipelineModule (pipelinePath: string | object, baseUrl: strin
     pipeline = moduleRelativePathOrURL.href
   }
   if (pipelineToModule.has(pipeline)) {
-    pipelineModule = pipelineToModule.get(pipeline) as PipelineEmscriptenModule
+    pipelineModule = await pipelineToModule.get(pipeline) as PipelineEmscriptenModule
   } else {
-    pipelineToModule.set(pipeline, await loadEmscriptenModule(moduleRelativePathOrURL, baseUrl) as PipelineEmscriptenModule)
-    pipelineModule = pipelineToModule.get(pipeline) as PipelineEmscriptenModule
+    pipelineToModule.set(pipeline, loadEmscriptenModule(moduleRelativePathOrURL, baseUrl) as Promise<PipelineEmscriptenModule>)
+    pipelineModule = await pipelineToModule.get(pipeline) as PipelineEmscriptenModule
   }
   return pipelineModule
 }


### PR DESCRIPTION
Presently, calling `loadPipelineModule` multiple times with the same pipeline in quick succession will cause multiple network requests to go out to fetch the pipeline code. This change coalesces multiple calls into a single pipeline fetch.