### PR TITLE
fix(wasi-function-module): use file path variable name

### DIFF
--- a/packages/core/typescript/itk-wasm/src/bindgen/python/wasi/wasi-function-module.js
+++ b/packages/core/typescript/itk-wasm/src/bindgen/python/wasi/wasi-function-module.js
@@ -180,7 +180,7 @@ from itkwasm import (
         const interfaceType = interfaceJsonTypeToInterfaceType.get(parameter.type)
         if (interfaceType.includes('File')) {
           // for files
-          args += `            input_file = str(PurePosixPath(${snakeCase(parameter.name)}))\n`
+          args += `            input_file = str(PurePosixPath(value))\n`
           args += `            pipeline_inputs.append(PipelineInput(InterfaceTypes.${interfaceType}, ${interfaceType}(value)))\n`
           args += `            args.append(input_file)\n`
         } else if (interfaceType.includes('Stream')) {


### PR DESCRIPTION
Getting runtime type error in `path` with 
```
        for value in files:
            input_file = str(PurePosixPath(files))
``` 
Changes to 
```
        for value in files:
            input_file = str(PurePosixPath(value))
``` 