### PR TITLE
test(itk-wasm): avoid use of npm link in bindgen test for Windows

### DIFF
--- a/packages/core/typescript/itk-wasm/package.json
+++ b/packages/core/typescript/itk-wasm/package.json
@@ -32,7 +32,7 @@
     "cypress:runChrome": "pnpm exec cypress run --config defaultCommandTimeout=8000 --browser chrome",
     "cypress:runFirefox": "pnpm exec cypress run --config defaultCommandTimeout=8000 --browser firefox",
     "cypress:runFirefox:ci": "pnpm cypress:install && pnpm exec cypress run --config defaultCommandTimeout=8000 --browser firefox",
-    "start": "pnpm build:workerBundleForTesting && cd test/pipelines/typescript && npm i && npm link ../../.. && npm run build && npm run start",
+    "start": "pnpm build:workerBundleForTesting && cd test/pipelines/typescript && pnpm build && pnpm start",
     "test:wasi": "pnpm test:buildTestPipelines:wasi && pnpm test:runTestPipelines && pnpm test:bindgenTestPipelines:python",
     "test": "pnpm test:lint && pnpm test:testPipelines && pnpm test:node && pnpm test:bindgenTestPipelines:python && pnpm test:browser:chrome && pnpm test:browser:firefox",
     "test:lint": "ts-standard --fix \"src/**/*.ts\" && standard --fix \"test/node/**/*.js\"",

--- a/packages/core/typescript/itk-wasm/test/pipelines/typescript/package.json
+++ b/packages/core/typescript/itk-wasm/test/pipelines/typescript/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "test-pipelines",
+  "version": "1.0.0",
+  "packageManager": "pnpm@8.11.0",
+  "description": "Exercise interface types for bindgen",
+  "type": "module",
+  "module": "./dist/index.js",
+  "types": "./dist/index-all.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index-all.d.ts",
+      "browser": "./dist/index.js",
+      "node": "./dist/index-node.js",
+      "default": "./dist/index-all.js"
+    }
+  },
+  "scripts": {
+    "start": "pnpm copyShoelaceAssets && vite",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "pnpm build:tsc && pnpm build:browser:workerEmbedded && pnpm build:browser:workerEmbeddedMin && pnpm build:demo",
+    "build:browser:workerEmbedded": "esbuild --loader:.worker.js=dataurl --bundle --format=esm --outfile=./dist/bundle/index-worker-embedded.js ./src/index-worker-embedded.ts",
+    "build:browser:workerEmbeddedMin": "esbuild --minify --loader:.worker.js=dataurl --bundle --format=esm --outfile=./dist/bundle/index-worker-embedded.min.js ./src/index-worker-embedded.min.ts",
+    "build:version": "node -p \"'const version = ' + JSON.stringify(require('./package.json').version) + '\\nexport default version\\n'\" > src/version.ts",
+    "build:tsc": "pnpm build:version && tsc --pretty",
+    "copyShoelaceAssets": "shx mkdir -p test/browser/demo-app/public && shx cp -r node_modules/@shoelace-style/shoelace/dist/assets test/browser/demo-app/public/",
+    "build:demo": "pnpm copyShoelaceAssets && vite build"
+  },
+  "keywords": [
+    "itk",
+    "wasm",
+    "webassembly",
+    "wasi"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "itk-wasm": "workspace:*"
+  },
+  "devDependencies": {
+    "@itk-wasm/image-io": "workspace:*",
+    "@itk-wasm/mesh-io": "workspace:*",
+    "@shoelace-style/shoelace": "^2.12.0",
+    "@types/node": "^20.2.5",
+    "esbuild": "^0.19.8",
+    "shx": "^0.3.4",
+    "typescript": "^5.3.2",
+    "vite": "^4.5.0",
+    "vite-plugin-static-copy": "^0.17.0"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,6 +369,40 @@ importers:
         specifier: ^5.3.2
         version: 5.3.2
 
+  packages/core/typescript/itk-wasm/test/pipelines/typescript:
+    dependencies:
+      itk-wasm:
+        specifier: workspace:*
+        version: link:../../..
+    devDependencies:
+      '@itk-wasm/image-io':
+        specifier: workspace:*
+        version: link:../../../../../../image-io/typescript
+      '@itk-wasm/mesh-io':
+        specifier: workspace:*
+        version: link:../../../../../../mesh-io/typescript
+      '@shoelace-style/shoelace':
+        specifier: ^2.12.0
+        version: 2.12.0(@types/react@18.2.42)
+      '@types/node':
+        specifier: ^20.2.5
+        version: 20.11.16
+      esbuild:
+        specifier: ^0.19.8
+        version: 0.19.9
+      shx:
+        specifier: ^0.3.4
+        version: 0.3.4
+      typescript:
+        specifier: ^5.3.2
+        version: 5.3.3
+      vite:
+        specifier: ^4.5.0
+        version: 4.5.1(@types/node@20.11.16)
+      vite-plugin-static-copy:
+        specifier: ^0.17.0
+        version: 0.17.1(vite@4.5.1)
+
   packages/dicom:
     devDependencies:
       '@itk-wasm/dam':
@@ -7506,6 +7540,42 @@ packages:
         optional: true
     dependencies:
       '@types/node': 20.10.4
+      esbuild: 0.18.20
+      postcss: 8.4.32
+      rollup: 3.29.4
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vite@4.5.1(@types/node@20.11.16):
+    resolution: {integrity: sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': '>= 14'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 20.11.16
       esbuild: 0.18.20
       postcss: 8.4.32
       rollup: 3.29.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,6 @@ packages:
   - 'examples/inputs-outputs/typescript'
   - 'examples/mean-squares-versor-registration'
   - 'examples/mean-squares-versor-registration/typescript'
-  - '!packages/core/typescript/itk-wasm/test/pipelines/typescript'
   - '!packages/core/typescript/create-itk-wasm/test/**'
   - '!**/src'
   - '!**/dist'


### PR DESCRIPTION
lstat not found errors from npm.