### PR TITLE
fix(create-web-worker): allow undefined workerUrl

### DIFF
--- a/packages/core/typescript/itk-wasm/src/pipeline/create-web-worker.ts
+++ b/packages/core/typescript/itk-wasm/src/pipeline/create-web-worker.ts
@@ -4,18 +4,18 @@ import RunPipelineOptions from './run-pipeline-options'
 async function createWebWorker (pipelineWorkerUrl?: string | null, queryParams?: RunPipelineOptions['pipelineQueryParams']): Promise<Worker> {
   const workerUrl = pipelineWorkerUrl
   let worker = null
-  if (workerUrl === null) {
+  if (workerUrl == null) {
     // Use the version built with the bundler
     //
     // Bundlers, e.g. WebPack, Vite, Rollup, see these paths at build time
     worker = new Worker(new URL('./web-workers/itk-wasm-pipeline.worker.js', import.meta.url), { type: 'module' })
   } else {
-    if ((workerUrl as string).startsWith('http')) {
-      const response = await axios.get((workerUrl as string), { responseType: 'blob', params: queryParams })
+    if (workerUrl.startsWith('http')) {
+      const response = await axios.get(workerUrl, { responseType: 'blob', params: queryParams })
       const workerObjectUrl = URL.createObjectURL(response.data as Blob)
       worker = new Worker(workerObjectUrl, { type: 'module' })
     } else {
-      worker = new Worker((workerUrl as string), { type: 'module' })
+      worker = new Worker(workerUrl, { type: 'module' })
     }
   }
 


### PR DESCRIPTION
Calling `createWebWorker()` with an undefined `pipelineWorkerUrl` should be equivalent to passing in `null`.