### PR TITLE
docker image bump

### DIFF
--- a/packages/core/typescript/itk-wasm/src/cli/default-image-tag.js
+++ b/packages/core/typescript/itk-wasm/src/cli/default-image-tag.js
@@ -1,2 +1,2 @@
-const defaultImageTag = '20240413-b75cd2b9'
+const defaultImageTag = '20240415-8c69d3f8'
 export default defaultImageTag

--- a/src/docker/RELEASE.md
+++ b/src/docker/RELEASE.md
@@ -17,6 +17,9 @@ pnpm i
 ./src/docker/build.sh --with-debug --multiarch
 # DockerHub credential environmental variables must be set
 ./src/docker/push.sh
+
+pnpm build && pnpm test
+
 git add -- packages/core/typescript/itk-wasm/src/cli/default-image-tag.js
 git commit -m "feat(itk-wasm-cli): Update default Docker image for $(date '+%Y%m%d')-$(git rev-parse --short HEAD)"
 ```

--- a/src/docker/itk-wasm-base/Dockerfile
+++ b/src/docker/itk-wasm-base/Dockerfile
@@ -8,7 +8,7 @@ LABEL org.opencontainers.image.source="https://github.com/InsightSoftwareConsort
 WORKDIR /
 
 # Note: on entry, emsdk will prepend to the path with its own node, so add to an earlier path
-ENV NODE_TAG v18.17.1
+ENV NODE_TAG v20.12.2
 RUN curl -LO https://nodejs.org/dist/${NODE_TAG}/node-${NODE_TAG}-linux-x64.tar.xz && \
   tar xvJf node-${NODE_TAG}-linux-x64.tar.xz && \
   rm node-${NODE_TAG}-linux-x64.tar.xz && \


### PR DESCRIPTION
- chore(docker): bump Node version to 20.12.2
- feat(itk-wasm-cli): Update default Docker image for 20240415-8c69d3f8
- docs(docker): document build, test as part of the image release process
