### PR TITLE
fix(bindgen): remove packageManager version from template.package.json

### DIFF
--- a/packages/core/typescript/itk-wasm/src/bindgen/typescript/resources/template.package.json
+++ b/packages/core/typescript/itk-wasm/src/bindgen/typescript/resources/template.package.json
@@ -1,7 +1,6 @@
 {
   "name": "package-name",
   "version": "0.1.0",
-  "packageManager": "pnpm@9.1.0",
   "description": "",
   "type": "module",
   "module": "./dist/index.js",


### PR DESCRIPTION
This is likely to get out-of-sync and conflict with the itk-wasm build
scripts package.json packageManager pnpm version.
