### PR TITLE
itk 5.4.0 docker

### DIFF
--- a/packages/core/typescript/itk-wasm/src/cli/default-image-tag.js
+++ b/packages/core/typescript/itk-wasm/src/cli/default-image-tag.js
@@ -1,2 +1,2 @@
-const defaultImageTag = '20240517-32a1ffd9'
+const defaultImageTag = '20240521-17db8b0b'
 export default defaultImageTag

--- a/src/docker/itk-wasm-base/Dockerfile
+++ b/src/docker/itk-wasm-base/Dockerfile
@@ -33,9 +33,9 @@ RUN curl -L https://api.github.com/repos/facebook/zstd/tarball/${zstd_GIT_TAG} |
   cd .. && \
   rm -rf zstd-build zstd
 
-# tag commit date: 2024-05-05 branch: itkwasm-2024-05-03-e5a84a08a30
-ENV ITK_GIT_TAG 2282cb5b41d1333fd68ba14af4cbc5a1c0d0f965
-ENV ITK_GIT_BRANCH itkwasm-2024-05-03-e5a84a08a30
+# tag commit date: 2024-05-21
+ENV ITK_GIT_TAG d03c2616856b28f708002cd1eff9b79660c7c9b0
+ENV ITK_GIT_BRANCH itkwasm-2024-05-20-5db055d7ad3b
 RUN git clone --branch $ITK_GIT_BRANCH --single-branch --depth 1 https://github.com/KitwareMedical/ITK.git && \
   sed -i -e '/^option(OPJ_USE_THREAD/c\option(OPJ_USE_THREAD "use threads" OFF)' \
     /ITK/Modules/ThirdParty/GDCM/src/gdcm/Utilities/gdcmopenjpeg/src/lib/openjp2/CMakeLists.txt


### PR DESCRIPTION
- build(docker): bump ITK to v5.4.0
- feat(itk-wasm-cli): Update default Docker image for 20240521-17db8b0b
