### PR TITLE
create itk wasm tweaks

### DIFF
--- a/packages/core/typescript/create-itk-wasm/package.json
+++ b/packages/core/typescript/create-itk-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-itk-wasm",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "CLI to create a new ITK-Wasm project or add a pipeline to an existing project.",
   "type": "module",
   "exports": {

--- a/packages/core/typescript/create-itk-wasm/src/generate/package-json.ts
+++ b/packages/core/typescript/create-itk-wasm/src/generate/package-json.ts
@@ -59,7 +59,7 @@ function generatePackageJson(project: ProjectSpec) {
     devDependencies: {
       '@itk-wasm/dam': '^1.1.1',
       '@thewtex/setup-micromamba': '^1.9.7',
-      'itk-wasm': '1.0.0-b.173'
+      'itk-wasm': '1.0.0-b.175'
     }
   }
   if (project.author) {

--- a/packages/core/typescript/create-itk-wasm/src/inquire/edit-wanted-machine.ts
+++ b/packages/core/typescript/create-itk-wasm/src/inquire/edit-wanted-machine.ts
@@ -171,7 +171,7 @@ const inquireEditWantedMachine = setup({
           return { spec: context.spec, specName: context.specName }
         },
         onDone: {
-          target: 'obtainedReponse',
+          target: 'obtainedResponse',
           actions: [
             assign({ response: ({ event }) => event.output as boolean }),
             'sendResponse'
@@ -179,7 +179,7 @@ const inquireEditWantedMachine = setup({
         }
       }
     },
-    obtainedReponse: {
+    obtainedResponse: {
       type: 'final'
     }
   }

--- a/packages/core/typescript/create-itk-wasm/src/inquire/project-spec.ts
+++ b/packages/core/typescript/create-itk-wasm/src/inquire/project-spec.ts
@@ -48,9 +48,15 @@ async function inquireProjectSpec(
     {
       type: 'input',
       name: 'packageDescription',
-      message: 'Description:',
+      message: 'Package Description:',
       askAnswered,
-      default: project.packageDescription
+      default: project.packageDescription,
+      validate: (input: string) => {
+        if (input.length > 0) {
+          return true
+        }
+        return 'Description cannot be empty.'
+      }
     },
     {
       type: 'input',


### PR DESCRIPTION
- chore(create-itk-wasm): bump itk-wasm version to 1.0.0-b.175
- style(create-itk-wasm): obtainedReponse -> obtainedResponse
- fix(create-itk-wasm): input project description must not be empty
- fix(create-itk-wasm): support dispatch on parameters
