### PR TITLE
ci: avoid duplicate builds on push, pull_request

### DIFF
--- a/.github/workflows/cxx-python.yml
+++ b/.github/workflows/cxx-python.yml
@@ -1,6 +1,12 @@
 name: C++,Native Python
 
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 env:
   ITKMeshToPolyData-git-tag: "v0.11.0"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,6 +1,12 @@
 name: Browser Tests
 
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 defaults:
   run:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,6 +1,12 @@
 name: Examples
 
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test-node-example:

--- a/.github/workflows/javascript-typescript.yml
+++ b/.github/workflows/javascript-typescript.yml
@@ -1,6 +1,12 @@
 name: Node.js Tests
 
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 defaults:
   run:

--- a/.github/workflows/python-wasm.yml
+++ b/.github/workflows/python-wasm.yml
@@ -1,6 +1,12 @@
 name: Python Wasm
 
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 env:
   pyodide-version: 0.24.1

--- a/.github/workflows/toolchains.yml
+++ b/.github/workflows/toolchains.yml
@@ -1,6 +1,12 @@
 name: Toolchains
 
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 env:
   OCI_EXE: docker

--- a/.github/workflows/wasi.yml
+++ b/.github/workflows/wasi.yml
@@ -1,6 +1,12 @@
 name: WASI
 
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 defaults:
   run:


### PR DESCRIPTION
Only build push's to `main` to avoid duplicate builds.
