### PR TITLE
Fix itkPipeline help stream parsing crash and native msvc static debug build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,20 @@ endif()
 
 set(WebAssemblyInterface_LIBRARIES WebAssemblyInterface)
 
+if(MSVC) #-- Configure MSVC_STATIC_RUNTIME only if using MSVC environment
+  option(ITKWASM_MSVC_STATIC_RUNTIME_LIBRARY "Link to MSVC's static CRT (/MT and /MTd).
+OFF (default) means link to regular, dynamic CRT (/MD and /MDd)." ON)
+  mark_as_advanced(ITKWASM_MSVC_STATIC_RUNTIME_LIBRARY)
+  set(ITKWASM_MSVC_STATIC_RUNTIME_LIBRARY_value ${ITK_MSVC_STATIC_RUNTIME_LIBRARY})
+  if(ITKWASM_MSVC_STATIC_RUNTIME_LIBRARY)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    message(STATUS "Using MSVC's static CRT (/MT and /MTd)")
+  else()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    message(STATUS "Using MSVC's dynamic CRT (/MD and /MDd)")
+  endif()
+endif()
+
 include(FetchContent)
 set(_itk_build_testing ${BUILD_TESTING})
 set(BUILD_TESTING OFF)

--- a/src/itkPipeline.cxx
+++ b/src/itkPipeline.cxx
@@ -207,7 +207,9 @@ Pipeline
 #ifndef ITK_WASM_NO_FILESYSTEM_IO
           std::cout << rang::fg::reset;
 #endif
-          std::cout << line.substr(loc) << std::endl;
+          if (loc == std::string::npos) {
+            std::cout << line.substr(loc) << std::endl;
+          }
         }
       } else if(optionGroup) {
         if (line == "") {


### PR DESCRIPTION
# fix(itkPipeline): parameters parsing crash when no space in line 

Fix a bug where a call to --help and printing of parameters for
a cli app would crash if a description or parameter line
did not contain any space.

# build(msvc): add cmake flag to enable msvc static runtime debug library 

ITK-Wasm prefers static build. For native build on windows (msvc),
it is necessary to enable/specify the use of static runtime debug
library indicated by the /MTd compiler flag.
Add a CMAKE flag (default: ON) to enable/disable this compiler
flag when msvc is being used for building.