### PR TITLE
fix(OutputImage): dataSize needs components per pixel

### DIFF
--- a/include/itkOutputImage.h
+++ b/include/itkOutputImage.h
@@ -84,7 +84,7 @@ public:
 
         const auto dataAddress = reinterpret_cast< size_t >( wasmImage->GetImage()->GetBufferPointer() );
         using ConvertPixelTraits = DefaultConvertPixelTraits<typename ImageType::PixelType>;
-        const auto dataSize = wasmImage->GetImage()->GetPixelContainer()->Size() * sizeof(typename ConvertPixelTraits::ComponentType);
+        const auto dataSize = wasmImage->GetImage()->GetPixelContainer()->Size() * sizeof(typename ConvertPixelTraits::ComponentType) * ConvertPixelTraits::GetNumberOfComponents();
         setMemoryStoreOutputArray(0, index, 0, dataAddress, dataSize);
 
         const auto directionAddress = reinterpret_cast< size_t >( wasmImage->GetImage()->GetDirection().GetVnlMatrix().begin() );

--- a/packages/core/typescript/itk-wasm/src/cli/default-image-tag.js
+++ b/packages/core/typescript/itk-wasm/src/cli/default-image-tag.js
@@ -1,2 +1,2 @@
-const defaultImageTag = '20240713-c8dabc4b'
+const defaultImageTag = '20240717-6891d4df'
 export default defaultImageTag


### PR DESCRIPTION
As a follow-up to f9f2805766ae1da281dc35dc6c1b3405911007f3, we still
need the component per pixel when computing the data size.