### PR TITLE
STYLE: Specify ReadTheDocs custom domain name

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,14 @@ project = 'ITK-Wasm'
 copyright = f'{date.today().year}, NumFOCUS'
 author = 'Matt McCormick'
 
+# Define the canonical URL if you are using a custom domain on Read the Docs
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "wasm.itk.org")
+
+html_context = {}
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True
+
 extensions = [
     'sphinx.ext.napoleon',
     'autodoc2',


### PR DESCRIPTION
Specify the Read The Docs custom domain in the documentation config file.

Read the Docs is deprecating Sphinx context injection at build time starting Monday, Oct 7, 2024, so any custom domain specified in the Read the Docs admin needs to be defined in the configuration file.

Documentation:
https://about.readthedocs.com/blog/2024/07/addons-by-default/
