### PR TITLE
build(index-worker-embedded): specify pipelineWorker type

### DIFF
--- a/packages/core/typescript/itk-wasm/src/bindgen/typescript/resources/index-worker-embedded.ts
+++ b/packages/core/typescript/itk-wasm/src/bindgen/typescript/resources/index-worker-embedded.ts
@@ -2,6 +2,6 @@
 
 import { setPipelineWorkerUrl } from './index.js'
 import pipelineWorker from '../node_modules/itk-wasm/dist/pipeline/web-workers/bundles/itk-wasm-pipeline.worker.js'
-setPipelineWorkerUrl(pipelineWorker)
+setPipelineWorkerUrl(pipelineWorker as string)
 
 export * from './index.js'


### PR DESCRIPTION
Avoid implicit `any`. `string` may not be technically right -- this
`.worker.js` is a worker module source treated specially by bundlers.
