### PR TITLE
ci(native): add ref to setup-pixi

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: prefix-dev/setup-pixi
+      - uses: prefix-dev/setup-pixi@v0.8.1
 
       - name: Build and Test ITK-Wasm
         run: |

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
+      - uses: actions/checkout@v4
+
       - uses: prefix-dev/setup-pixi@v0.8.1
 
       - name: Build and Test ITK-Wasm


### PR DESCRIPTION
To address:

> Error
> the `uses' attribute must be a path, a Docker image, or owner/repo@ref
