### PR TITLE
fix(include): avoid segfault when calculating totalSize

### DIFF
--- a/include/itkWasmImageToImageFilter.hxx
+++ b/include/itkWasmImageToImageFilter.hxx
@@ -213,13 +213,14 @@ WasmImageToImageFilter<TImage>
     {
       bufferedRegion.SetIndex(i, imageJSON.bufferedRegion.index[i]);
       bufferedRegion.SetSize(i, imageJSON.bufferedRegion.size[i]);
+      totalSize *= imageJSON.bufferedRegion.size[i];
     }
     else
     {
       bufferedRegion.SetIndex(i, 0);
       bufferedRegion.SetSize(i, imageJSON.size[i]);
+      totalSize *= imageJSON.size[i];
     }
-    totalSize *= imageJSON.bufferedRegion.size[i];
     largestRegion.SetSize(i, imageJSON.size[i]);
   }
   filter->SetBufferedRegion(bufferedRegion);


### PR DESCRIPTION
Hi,

This PR fixes an issue in which a segfault could occur when calculating the total size of the buffered region. If my understanding is correct here, `imageJSON.size[i]` should be used if `imageJSON.bufferedRegion.size` is undefined.

Related thread on the ITK forum: https://discourse.itk.org/t/running-pipeline-inputs-outputs-tutorial-in-browser/7282
