### PR TITLE
build(pyproject.toml): replace license with license-expression

### DIFF
--- a/packages/compare-images/python/itkwasm-compare-images-emscripten/pyproject.toml
+++ b/packages/compare-images/python/itkwasm-compare-images-emscripten/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-compare-images-emscripten"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version", "description"]
 classifiers = [
   "License :: OSI Approved :: Apache Software License",

--- a/packages/compare-images/python/itkwasm-compare-images-wasi/pyproject.toml
+++ b/packages/compare-images/python/itkwasm-compare-images-wasi/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-compare-images-wasi"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version", "description"]
 classifiers = [
   "License :: OSI Approved :: Apache Software License",

--- a/packages/compare-images/python/itkwasm-compare-images/pyproject.toml
+++ b/packages/compare-images/python/itkwasm-compare-images/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-compare-images"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Compare images with a tolerance for regression testing."
 classifiers = [

--- a/packages/compress-stringify/python/itkwasm-compress-stringify-emscripten/pyproject.toml
+++ b/packages/compress-stringify/python/itkwasm-compress-stringify-emscripten/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-compress-stringify-emscripten"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version", "description"]
 classifiers = [
   "License :: OSI Approved :: Apache Software License",

--- a/packages/compress-stringify/python/itkwasm-compress-stringify-wasi/pyproject.toml
+++ b/packages/compress-stringify/python/itkwasm-compress-stringify-wasi/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-compress-stringify-wasi"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version", "description"]
 classifiers = [
   "License :: OSI Approved :: Apache Software License",

--- a/packages/compress-stringify/python/itkwasm-compress-stringify/pyproject.toml
+++ b/packages/compress-stringify/python/itkwasm-compress-stringify/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-compress-stringify"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Zstandard compression and decompression and base64 encoding and decoding in WebAssembly."
 classifiers = [

--- a/packages/core/python/itkwasm/test/test-accelerator/pyproject.toml
+++ b/packages/core/python/itkwasm/test/test-accelerator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "test-accelerator"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 version = "0.0.1"
 
 requires-python = ">=3.8"

--- a/packages/core/typescript/itk-wasm/src/bindgen/python/resources/template.pyproject.toml
+++ b/packages/core/typescript/itk-wasm/src/bindgen/python/resources/template.pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "@bindgenPackageName@"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "@bindgenPackageDescription@"
 classifiers = [

--- a/packages/core/typescript/itk-wasm/test/pipelines/bindgen-interface-types-pipeline/python/itkwasm-bindgen-interface-types-test-wasi/pyproject.toml
+++ b/packages/core/typescript/itk-wasm/test/pipelines/bindgen-interface-types-pipeline/python/itkwasm-bindgen-interface-types-test-wasi/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-bindgen-interface-types-test-wasi"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Exercise interface types for bindgen"
 classifiers = [

--- a/packages/core/typescript/itk-wasm/test/pipelines/bindgen-interface-types-pipeline/python/itkwasm-bindgen-interface-types-test/pyproject.toml
+++ b/packages/core/typescript/itk-wasm/test/pipelines/bindgen-interface-types-pipeline/python/itkwasm-bindgen-interface-types-test/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-bindgen-interface-types-test"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Exercise interface types for bindgen"
 classifiers = [

--- a/packages/dicom/python/itkwasm-dicom-emscripten/pyproject.toml
+++ b/packages/dicom/python/itkwasm-dicom-emscripten/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-dicom-emscripten"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version", "description"]
 classifiers = [
   "License :: OSI Approved :: Apache Software License",

--- a/packages/dicom/python/itkwasm-dicom-wasi/pyproject.toml
+++ b/packages/dicom/python/itkwasm-dicom-wasi/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-dicom-wasi"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version", "description"]
 classifiers = [
   "License :: OSI Approved :: Apache Software License",

--- a/packages/dicom/python/itkwasm-dicom/pyproject.toml
+++ b/packages/dicom/python/itkwasm-dicom/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-dicom"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Read files and images related to DICOM file format."
 classifiers = [

--- a/packages/downsample/python/itkwasm-downsample-cucim/pyproject.toml
+++ b/packages/downsample/python/itkwasm-downsample-cucim/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-downsample-cucim"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Pipelines for downsampling images. cuCIM implementation."
 classifiers = [

--- a/packages/downsample/python/itkwasm-downsample-emscripten/pyproject.toml
+++ b/packages/downsample/python/itkwasm-downsample-emscripten/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-downsample-emscripten"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Pipelines for downsampling images."
 classifiers = [

--- a/packages/downsample/python/itkwasm-downsample-wasi/pyproject.toml
+++ b/packages/downsample/python/itkwasm-downsample-wasi/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-downsample-wasi"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Pipelines for downsampling images."
 classifiers = [

--- a/packages/downsample/python/itkwasm-downsample/pyproject.toml
+++ b/packages/downsample/python/itkwasm-downsample/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-downsample"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Pipelines for downsampling images."
 classifiers = [

--- a/packages/image-io/python/itkwasm-image-io-emscripten/pyproject.toml
+++ b/packages/image-io/python/itkwasm-image-io-emscripten/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-image-io-emscripten"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Input and output for scientific and medical image file formats."
 classifiers = [

--- a/packages/image-io/python/itkwasm-image-io-wasi/pyproject.toml
+++ b/packages/image-io/python/itkwasm-image-io-wasi/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-image-io-wasi"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Input and output for scientific and medical image file formats."
 classifiers = [

--- a/packages/image-io/python/itkwasm-image-io/pyproject.toml
+++ b/packages/image-io/python/itkwasm-image-io/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-image-io"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Input and output for scientific and medical image file formats."
 classifiers = [

--- a/packages/mesh-io/python/itkwasm-mesh-io-emscripten/pyproject.toml
+++ b/packages/mesh-io/python/itkwasm-mesh-io-emscripten/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-mesh-io-emscripten"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Input and output for scientific and medical image file formats."
 classifiers = [

--- a/packages/mesh-io/python/itkwasm-mesh-io-wasi/pyproject.toml
+++ b/packages/mesh-io/python/itkwasm-mesh-io-wasi/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-mesh-io-wasi"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Input and output for scientific and medical image file formats."
 classifiers = [

--- a/packages/mesh-io/python/itkwasm-mesh-io/pyproject.toml
+++ b/packages/mesh-io/python/itkwasm-mesh-io/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-mesh-io"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Input and output for scientific and medical image file formats."
 classifiers = [

--- a/packages/transform-io/python/itkwasm-transform-io-emscripten/pyproject.toml
+++ b/packages/transform-io/python/itkwasm-transform-io-emscripten/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-transform-io-emscripten"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Input and output for scientific and medical coordinate transform file formats."
 classifiers = [

--- a/packages/transform-io/python/itkwasm-transform-io-wasi/pyproject.toml
+++ b/packages/transform-io/python/itkwasm-transform-io-wasi/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-transform-io-wasi"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Input and output for scientific and medical coordinate transform file formats."
 classifiers = [

--- a/packages/transform-io/python/itkwasm-transform-io/pyproject.toml
+++ b/packages/transform-io/python/itkwasm-transform-io/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "itkwasm-transform-io"
 readme = "README.md"
-license = "Apache-2.0"
+license-expression = "Apache-2.0"
 dynamic = ["version"]
 description = "Input and output for scientific and medical coordinate transform file formats."
 classifiers = [


### PR DESCRIPTION
`license` is deprecated in favor of `license-expression` with
pyproject.toml `metadata-version` 2.4 and newer.

Ref:

- https://peps.python.org/pep-0639/#term-license-expression
- https://packaging.python.org/en/latest/specifications/core-metadata/#license-expression
