### PR TITLE
wasi push

### DIFF
--- a/packages/core/typescript/itk-wasm/src/cli/default-image-tag.js
+++ b/packages/core/typescript/itk-wasm/src/cli/default-image-tag.js
@@ -1,2 +1,2 @@
-const defaultImageTag = '20241230-6a87601b'
+const defaultImageTag = '20241231-76748372'
 export default defaultImageTag

--- a/src/docker/itk-wasm/build.sh
+++ b/src/docker/itk-wasm/build.sh
@@ -150,6 +150,11 @@ if $create_manifest; then
       quay.io/itkwasm/wasi:${TAG} \
       quay.io/itkwasm/wasi:latest-debug \
       quay.io/itkwasm/wasi:${TAG}-debug; do
+    if [ "$(buildah images -q $list 2>/dev/null)" != "" ]; then
+      if ! $(buildah manifest exists $list); then
+        buildah rmi $list
+      fi
+    fi
     if $(buildah manifest exists $list); then
       buildah manifest rm $list
     fi

--- a/src/docker/itk-wasm/build.sh
+++ b/src/docker/itk-wasm/build.sh
@@ -161,6 +161,6 @@ if $create_manifest; then
     buildah manifest create $list
     buildah manifest add ${list} ${list}-amd64
     buildah pull $list-arm64
-    buildah manifest add ${list} docker://${list}-arm64
+    buildah manifest add ${list} ${list}-arm64
   done
 fi


### PR DESCRIPTION
- build(docker): remove images of the same name before creating manifests
- feat(itk-wasm-cli): Update default Docker image for 20250102-76748372
- build(docker): fix manifest generation
