### PR TITLE
build(itk-wasm): generate index-wasm-worker-embedded.js

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -62,17 +62,18 @@ jobs:
         large-packages: false
         tool-cache: true
 
+    - name: Install
+      uses: pnpm/action-setup@v4
+      with:
+        run_install: true
+
     - uses: actions/setup-node@v4
       with:
         node-version: '22'
 
-    - name: Install
-      run: |
-        npm install
-
     - name: Build
       run: |
-        npm run build
+        pnpm build
 
     - name: Save wasm builds
       uses: actions/upload-artifact@v4
@@ -108,7 +109,7 @@ jobs:
       #with:
         #working-directory: ./examples/hello-world
         #browser: chrome
-        #start: npm start
+        #start: pnpm start
 
   build-test-hello-pipeline-example:
     name: hello-pipeline build test

--- a/packages/core/typescript/itk-wasm/package.json
+++ b/packages/core/typescript/itk-wasm/package.json
@@ -18,10 +18,12 @@
     "test": "test"
   },
   "scripts": {
-    "build": "pnpm build:tsc && pnpm build:bundle && pnpm build:minBundle && pnpm build:workerBundle && pnpm build:workerMinBundle && pnpm test:buildTestPipelines:emscripten && pnpm test:bindgenTestPipelines:typescript",
+    "build": "pnpm build:tsc && pnpm build:bundle && pnpm build:minBundle && pnpm build:bundleWorkerEmbedded && pnpm build:minBundleWorkerEmbedded && pnpm build:workerBundle && pnpm build:workerMinBundle && pnpm test:buildTestPipelines:emscripten && pnpm test:bindgenTestPipelines:typescript",
     "build:tsc": "tsc --pretty",
     "build:bundle": "esbuild --bundle --format=esm --outfile=./dist/bundles/itk-wasm.js ./dist/index.js",
     "build:minBundle": "esbuild --minify --bundle --format=esm --outfile=./dist/bundles/itk-wasm.min.js ./dist/index.js",
+    "build:bundleWorkerEmbedded": "esbuild --loader:.worker.js=dataurl --bundle --format=esm --outfile=./dist/bundles/itk-wasm-worker-embedded.js ./dist/index-worker-embedded.js",
+    "build:minBundleWorkerEmbedded": "esbuild --loader:.worker.js=dataurl --minify --bundle --format=esm --outfile=./dist/bundles/itk-wasm-worker-embedded.min.js ./dist/index-worker-embedded.js",
     "build:workerBundle": "esbuild --bundle --format=esm --outfile=./dist/pipeline/web-workers/bundles/itk-wasm-pipeline.worker.js ./dist/pipeline/web-workers/itk-wasm-pipeline.worker.js",
     "build:workerBundleForTesting": "esbuild --bundle --format=esm --outfile=./test/pipelines/typescript/test/browser/demo-app/public/itk-wasm-pipeline.worker.js ./dist/pipeline/web-workers/itk-wasm-pipeline.worker.js && shx cp -r ./test/data/ ./test/pipelines/typescript/test/browser/demo-app/public/",
     "build:workerMinBundle": "esbuild --minify --bundle --format=esm --outfile=./dist/pipeline/web-workers/bundles/itk-wasm-pipeline.min.worker.js ./dist/pipeline/web-workers/itk-wasm-pipeline.worker.js",

--- a/packages/core/typescript/itk-wasm/src/index-worker-embedded.ts
+++ b/packages/core/typescript/itk-wasm/src/index-worker-embedded.ts
@@ -1,0 +1,6 @@
+import { setPipelineWorkerUrl } from './index.js'
+// @ts-expect-error: TS1192
+import pipelineWorker from './pipeline/web-workers/itk-wasm-pipeline.worker.js'
+setPipelineWorkerUrl(pipelineWorker as string)
+
+export * from './index.js'

--- a/packages/core/typescript/itk-wasm/tsconfig.json
+++ b/packages/core/typescript/itk-wasm/tsconfig.json
@@ -21,5 +21,5 @@
     "rootDir": "src/"
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/bindgen", "src/index-worker-embedded*.ts"]
+  "exclude": ["src/bindgen"]
 }


### PR DESCRIPTION
For direct use in the browser as an ESM.
