### PR TITLE
fix(polydata): add missing metadata in python dataclass

### DIFF
--- a/packages/core/python/itkwasm/itkwasm/polydata.py
+++ b/packages/core/python/itkwasm/itkwasm/polydata.py
@@ -53,6 +53,8 @@ class PolyData:
     numberOfCellPixels: int = 0
     cellData: Optional[ArrayLike] = None
 
+    metadata: Dict = field(default_factory=dict)
+
     def __post_init__(self):
         if isinstance(self.polyDataType, dict):
             self.polyDataType = PolyDataType(**self.polyDataType)

--- a/packages/core/python/itkwasm/test/test_polydata.py
+++ b/packages/core/python/itkwasm/test/test_polydata.py
@@ -5,4 +5,5 @@ from itkwasm import PolyData
 
 def test_polydata():
     itkwasm_polydata = PolyData()
+    assert isinstance(itkwasm_polydata.metadata, dict)
     itkwasm_polydata_dict = asdict(itkwasm_polydata)


### PR DESCRIPTION
For the MetaDataDictionary.
