### PR TITLE
build(compress-stringify): remove -build ts build dep

### DIFF
--- a/packages/compress-stringify/typescript/package.json
+++ b/packages/compress-stringify/typescript/package.json
@@ -45,7 +45,6 @@
   "devDependencies": {
     "@itk-wasm/compare-images": "workspace:*",
     "@itk-wasm/compare-meshes": "workspace:*",
-    "@itk-wasm/compress-stringify-build": "workspace:*",
     "@itk-wasm/image-io": "workspace:*",
     "@itk-wasm/mesh-io": "workspace:*",
     "@itk-wasm/mesh-to-poly-data": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -299,9 +299,6 @@ importers:
       '@itk-wasm/compare-meshes':
         specifier: workspace:*
         version: link:../../compare-meshes/typescript
-      '@itk-wasm/compress-stringify-build':
-        specifier: workspace:*
-        version: link:..
       '@itk-wasm/demo-app':
         specifier: workspace:*
         version: link:../../core/typescript/demo-app


### PR DESCRIPTION
This is not needed for our workflow and introduces problems for demo
docs deployment.
