### PR TITLE
ci(cxx): disable macos-13 build

### DIFF
--- a/.github/workflows/cxx-python.yml
+++ b/.github/workflows/cxx-python.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.2
+    uses: thewtex/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@disable-intel-mac
     with:
       itk-module-deps: 'MeshToPolyData@v0.11.1'
       ctest-options: '-E itkPipelineTest'

--- a/.github/workflows/python-wasm.yml
+++ b/.github/workflows/python-wasm.yml
@@ -52,7 +52,7 @@ jobs:
           run_install: true
 
       - uses: nick-fields/retry@v3
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
         with:
           max_attempts: 5
           timeout_minutes: 10


### PR DESCRIPTION
Workaround bugs in C++17 support.

Temporary workaround until #1354 is finalized.
