### PR TITLE
ci(cxx-python): remove explicit CMAKE_CXX_STANDARD

### DIFF
--- a/.github/workflows/cxx-python.yml
+++ b/.github/workflows/cxx-python.yml
@@ -17,7 +17,6 @@ jobs:
     with:
       itk-module-deps: 'MeshToPolyData@v0.11.1'
       ctest-options: '-E itkPipelineTest'
-      itk-cmake-options: '-DCMAKE_CXX_STANDARD:BOOL=20'
 
   #python-build-workflow:
     ## itk-wasm branch


### PR DESCRIPTION
Already set in our CMakeLists.txt.

Suggested-by: Niels Dekker <N.Dekker@lumc.nl>
