### PR TITLE
fix(itkwasm): fall back to the image size when the buffered region is empty

### DIFF
--- a/packages/core/python/itkwasm/itkwasm/pipeline.py
+++ b/packages/core/python/itkwasm/itkwasm/pipeline.py
@@ -462,7 +462,11 @@ class Pipeline:
                         image.imageType.componentType,
                         ri.wasmtime_lift(data_ptr, data_size),
                     )
-                    shape = list(image.bufferedRegion.size)[::-1]
+                    # Producers that predate the buffered region becoming the source
+                    # of the pixel shape leave it empty; fall back to the largest
+                    # possible region. Information-only outputs set it explicitly to
+                    # zeros, which is a non-empty list and so still wins.
+                    shape = list(image.bufferedRegion.size or image.size)[::-1]
                     if image.imageType.components > 1:
                         shape.append(image.imageType.components)
                     image.data = data_array.reshape(tuple(shape))

--- a/packages/core/python/itkwasm/itkwasm/pyodide.py
+++ b/packages/core/python/itkwasm/itkwasm/pyodide.py
@@ -83,8 +83,12 @@ def to_py(js_proxy):
         image_dict["direction"] = buffer_to_numpy_array(str(FloatTypes.Float64), image_dict["direction"]).reshape(
             (dimension, dimension)
         )
-        buffered_region = image_dict.get("bufferedRegion")
-        shape = list(buffered_region["size"] if buffered_region is not None else image_dict["size"])[::-1]
+        # Producers that predate the buffered region becoming the source
+        # of the pixel shape leave it absent or empty; fall back to the
+        # largest possible region. Information-only outputs set it
+        # explicitly to zeros, which is a non-empty list and so still wins.
+        buffered_region = image_dict.get("bufferedRegion") or {}
+        shape = list(buffered_region.get("size") or image_dict["size"])[::-1]
         if image_type.components > 1:
             shape.append(image_type.components)
         if image_dict["data"] is not None:

--- a/packages/core/python/itkwasm/test/test_pipeline.py
+++ b/packages/core/python/itkwasm/test/test_pipeline.py
@@ -224,6 +224,61 @@ def test_pipeline_information_only_image(monkeypatch):
     assert image.data.shape == (0, 0)
 
 
+def test_pipeline_image_without_buffered_region(monkeypatch):
+    """Producers that leave the buffered region empty still reshape from size.
+
+    itkwasm-image-io returns images with an empty buffered region, so reading
+    from it would otherwise reshape to an empty tuple and raise.
+    """
+    import itkwasm.pipeline as pipeline_module
+
+    direction = np.eye(2, dtype=np.float64).tobytes()
+    pixels = np.arange(64, dtype=np.uint8).tobytes()
+
+    class NoBufferedRegionRunInstance:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def delayed_start(self):
+            return 0
+
+        def get_output_json(self, output_index):
+            return {
+                "imageType": {
+                    "dimension": 2,
+                    "componentType": "uint8",
+                    "pixelType": "Scalar",
+                    "components": 1,
+                },
+                "size": [8, 8],
+                "bufferedRegion": {"index": [], "size": []},
+            }
+
+        def get_output_array_address(self, memory, output_index, output_sub_index):
+            return output_sub_index
+
+        def get_output_array_size(self, memory, output_index, output_sub_index):
+            return len(pixels) if output_sub_index == 0 else len(direction)
+
+        def wasmtime_lift(self, ptr, size):
+            return pixels if size == len(pixels) else direction
+
+        def delayed_exit(self, return_code):
+            pass
+
+    monkeypatch.setattr(pipeline_module, "RunInstance", NoBufferedRegionRunInstance)
+    pipeline = object.__new__(Pipeline)
+    pipeline.engine = None
+    pipeline.linker = None
+    pipeline.module = None
+
+    outputs = pipeline.run([], [PipelineOutput(InterfaceTypes.Image)])
+    image = outputs[0].data
+
+    assert image.size == [8, 8]
+    assert image.data.shape == (8, 8)
+
+
 def test_pipeline_dask_array_input():
     pipeline = Pipeline(test_input_dir / "median-filter-test.wasi.wasm")
 

--- a/packages/core/python/itkwasm/test/test_pyodide.py
+++ b/packages/core/python/itkwasm/test/test_pyodide.py
@@ -92,6 +92,37 @@ async def test_image_conversion(selenium):
 
 @copy_files_to_pyodide(file_list=file_list, install_wheels=True)
 @run_in_pyodide(packages=["numpy"])
+async def test_image_conversion_without_buffered_region(selenium):
+    """Producers that leave the buffered region empty still reshape from size.
+
+    itkwasm-image-io returns images with an empty buffered region, so reading
+    them would otherwise reshape to an empty tuple and raise.
+    """
+    import js
+    import numpy as np
+    import pyodide.ffi
+
+    from itkwasm import Image
+    from itkwasm.pyodide import to_js, to_py
+
+    image = Image()
+    image.size = [4, 4]
+    image.data = np.arange(16, dtype=np.uint8).reshape((4, 4))
+
+    image_js = to_js(image)
+    image_js.bufferedRegion = pyodide.ffi.to_js(
+        {"index": [], "size": []}, dict_converter=js.Object.fromEntries
+    )
+
+    image_py = to_py(image_js)
+    assert image_py.size[0] == 4
+    assert image_py.size[1] == 4
+    assert image_py.data.shape == (4, 4)
+    assert np.array_equal(image_py.data, np.arange(16, dtype=np.uint8).reshape((4, 4)))
+
+
+@copy_files_to_pyodide(file_list=file_list, install_wheels=True)
+@run_in_pyodide(packages=["numpy"])
 async def test_point_set_conversion(selenium):
     from itkwasm import PointSet, PointSetType, PixelTypes, FloatTypes
     from itkwasm.pyodide import to_js, to_py


### PR DESCRIPTION
## Summary

```python
shape = list(image.bufferedRegion.size or image.size)[::-1]
```

## Context

#1545 switched the reshape source from `size` to `bufferedRegion.size`, which
information-only outputs need since they carry a logical size but no allocated
buffer.

Not every producer fills the buffered region though. Readers in
`itkwasm-image-io` 1.6.1 return it empty, so the reshape target became an
empty tuple and every read fails:

```python
from itkwasm_image_io import imread
imread("cthead1.png")
# ValueError: cannot reshape array of size 65536 into shape ()
```

```
1.0b195 + image-io 1.6.1  ->  OK,   bufferedRegion=[]
1.0b199 + image-io 1.6.1  ->  ValueError
```

The change landed on 30 June but only surfaced when 1.0b199 shipped, since
nothing was published in between.

Two producers use two conventions, and one line has to serve both:

| producer | `size` | `bufferedRegion` | correct source |
|---|---|---|---|
| information-only output | `[10,34,34]` | `[0,0,0]` | buffered region |
| file reader | `[256,256]` | `[]` | size |

`or` covers both without giving up either: `[0,0,0]` is a non-empty list and
still wins, `[]` falls back.

## Validation

`test_pipeline_image_without_buffered_region` mirrors the information-only
test from #1545 for the empty case. It fails without this change and passes
with it, and the information-only test keeps passing either way.

Core Python suite: 35 passed, 4 skipped, excluding the Pyodide and JS package
config tests.

Downstream, ngff-zarr went from 23 CI failures to 811 passed against a patched
1.0b199, and reading a file then downsampling it through
`itkwasm-downsample-cucim` works end to end on a GPU.

## Also worth a look

`pyodide.py` has a fallback but tests `is not None`, so it would miss this
case, which is a buffered region that is present with an empty size. Same
latent issue, same fix. I have not exercised that path.
