### PR TITLE
fix: set transform parameters by value when reconstructing from JSON

### DIFF
--- a/include/itkWasmTransformToTransformFilter.hxx
+++ b/include/itkWasmTransformToTransformFilter.hxx
@@ -21,6 +21,7 @@
 #include "itkTransformFactoryBase.h"
 
 #include "itktransformParameterizationString.h"
+#include <algorithm>
 #include <exception>
 #include "itkWasmMapComponentType.h"
 #include "itkWasmMapPixelType.h"
@@ -226,12 +227,30 @@ WasmTransformToTransformFilter<TTransform>::GenerateData()
       // Correct extra reference count from CreateInstance()
       ptr->UnRegister();
 
-      FixedParametersValueType * fixedPtr = reinterpret_cast<FixedParametersValueType *>(
+      // CopyIn*Parameters std::copy into m_FixedParameters/m_Parameters without resizing them.
+      // itk::BSplineTransform never sizes the base m_Parameters, so that overruns a zero-length
+      // buffer. Fixed parameters are set first: for a B-spline they define the grid, and hence
+      // the number of parameters.
+      const FixedParametersValueType * fixedPtr = reinterpret_cast<const FixedParametersValueType *>(
         std::strtoull(transformJSON.fixedParameters.substr(35).c_str(), nullptr, 10));
-      ptr->CopyInFixedParameters(fixedPtr, fixedPtr + transformJSON.numberOfFixedParameters);
-      ParametersValueType * paramsPtr = reinterpret_cast<ParametersValueType *>(
+      typename ComponentTransformType::FixedParametersType componentFixedParameters(
+        transformJSON.numberOfFixedParameters);
+      std::copy(fixedPtr,
+                fixedPtr + transformJSON.numberOfFixedParameters,
+                componentFixedParameters.data_block());
+      ptr->SetFixedParameters(componentFixedParameters);
+
+      const ParametersValueType * paramsPtr = reinterpret_cast<const ParametersValueType *>(
         std::strtoull(transformJSON.parameters.substr(35).c_str(), nullptr, 10));
-      ptr->CopyInParameters(paramsPtr, paramsPtr + transformJSON.numberOfParameters);
+      typename ComponentTransformType::ParametersType componentParameters(transformJSON.numberOfParameters);
+      std::copy(paramsPtr, paramsPtr + transformJSON.numberOfParameters, componentParameters.data_block());
+      if (componentParameters.Size() != ptr->GetNumberOfParameters())
+      {
+        itkExceptionMacro("The input transform carries " << componentParameters.Size() << " parameters but "
+                                                         << transformType << " expects "
+                                                         << ptr->GetNumberOfParameters() << '.');
+      }
+      ptr->SetParametersByValue(componentParameters);
 
       using CompositeTransformType = CompositeTransform<ParametersValueType, TransformType::InputSpaceDimension>;
       CompositeTransformType * compositeTransform = dynamic_cast<CompositeTransformType *>(transform);
@@ -239,12 +258,24 @@ WasmTransformToTransformFilter<TTransform>::GenerateData()
     }
     else
     {
-      FixedParametersValueType * fixedPtr = reinterpret_cast<FixedParametersValueType *>(
+      // Same reasoning as the composite branch above.
+      const FixedParametersValueType * fixedPtr = reinterpret_cast<const FixedParametersValueType *>(
         std::strtoull(transformJSON.fixedParameters.substr(35).c_str(), nullptr, 10));
-      transform->CopyInFixedParameters(fixedPtr, fixedPtr + transformJSON.numberOfFixedParameters);
-      ParametersValueType * paramsPtr = reinterpret_cast<ParametersValueType *>(
+      typename TransformType::FixedParametersType fixedParameters(transformJSON.numberOfFixedParameters);
+      std::copy(fixedPtr, fixedPtr + transformJSON.numberOfFixedParameters, fixedParameters.data_block());
+      transform->SetFixedParameters(fixedParameters);
+
+      const ParametersValueType * paramsPtr = reinterpret_cast<const ParametersValueType *>(
         std::strtoull(transformJSON.parameters.substr(35).c_str(), nullptr, 10));
-      transform->CopyInParameters(paramsPtr, paramsPtr + transformJSON.numberOfParameters);
+      typename TransformType::ParametersType parameters(transformJSON.numberOfParameters);
+      std::copy(paramsPtr, paramsPtr + transformJSON.numberOfParameters, parameters.data_block());
+      if (parameters.Size() != transform->GetNumberOfParameters())
+      {
+        itkExceptionMacro("The input transform carries " << parameters.Size() << " parameters but "
+                                                         << transformType << " expects "
+                                                         << transform->GetNumberOfParameters() << '.');
+      }
+      transform->SetParametersByValue(parameters);
 
       auto dictionary = transform->GetMetaDataDictionary();
       jsonToMetaDataDictionary(transformJSON.metadata, dictionary);

--- a/packages/downsample/resampleReadInputTransform.h
+++ b/packages/downsample/resampleReadInputTransform.h
@@ -51,6 +51,7 @@
 // the filesystem path robust to itk-wasm's .iwt scalar-type detection, which can misreport a float64 transform
 // as float32 (reading such a transform at single precision silently drops parameters).
 
+#include <algorithm>
 #include <cstdlib>
 #include <stdexcept>
 #include <string>
@@ -153,12 +154,22 @@ reconstructTransformEntry(const itk::TransformJSON & transformJSON)
   // The JSON encodes the parameter arrays as wasm memory addresses: "data:application/vnd.itk.address,0:<ptr>".
   constexpr std::string::size_type addressPrefixLength = 35;
 
+  // CopyIn*Parameters std::copy into m_FixedParameters/m_Parameters without resizing them.
+  // itk::BSplineTransform never sizes the base m_Parameters, so that overruns a zero-length buffer.
+  using FixedParametersType = typename TransformType::FixedParametersType;
+  using ParametersType = typename TransformType::ParametersType;
+
   // Fixed parameters are stored at double precision (itk::Transform::FixedParametersValueType is double).
+  // Set first: for a B-spline they define the grid, and hence the number of parameters.
   if (transformJSON.numberOfFixedParameters > 0)
   {
     const double * fixedParametersPtr = reinterpret_cast<const double *>(
       std::strtoull(transformJSON.fixedParameters.substr(addressPrefixLength).c_str(), nullptr, 10));
-    transform->CopyInFixedParameters(fixedParametersPtr, fixedParametersPtr + transformJSON.numberOfFixedParameters);
+    FixedParametersType fixedParameters(transformJSON.numberOfFixedParameters);
+    std::copy(fixedParametersPtr,
+              fixedParametersPtr + transformJSON.numberOfFixedParameters,
+              fixedParameters.data_block());
+    transform->SetFixedParameters(fixedParameters);
   }
 
   // Parameters are stored at the transform's own precision; cast into a double buffer so the double-precision
@@ -166,8 +177,8 @@ reconstructTransformEntry(const itk::TransformJSON & transformJSON)
   const std::size_t numberOfParameters = static_cast<std::size_t>(transformJSON.numberOfParameters);
   if (numberOfParameters > 0)
   {
-    std::vector<double> parameters(numberOfParameters);
-    const std::string   parametersAddress = transformJSON.parameters.substr(addressPrefixLength);
+    ParametersType    parameters(numberOfParameters);
+    const std::string parametersAddress = transformJSON.parameters.substr(addressPrefixLength);
     if (transformJSON.transformType.parametersValueType == itk::JSONFloatTypesEnum::float32)
     {
       const float * source = reinterpret_cast<const float *>(std::strtoull(parametersAddress.c_str(), nullptr, 10));
@@ -184,7 +195,13 @@ reconstructTransformEntry(const itk::TransformJSON & transformJSON)
         parameters[ii] = source[ii];
       }
     }
-    transform->CopyInParameters(parameters.data(), parameters.data() + numberOfParameters);
+    if (parameters.Size() != transform->GetNumberOfParameters())
+    {
+      throw std::runtime_error("The input transform carries " + std::to_string(parameters.Size()) +
+                               " parameters but " + typeString + " expects " +
+                               std::to_string(transform->GetNumberOfParameters()) + ".");
+    }
+    transform->SetParametersByValue(parameters);
   }
 
   return transform;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,6 +74,7 @@ set(WebAssemblyInterfaceTests
   itkTransformJSONTest.cxx
   itkWasmTransformInterfaceTest.cxx
   itkWasmTransformInterfaceCompositeTest.cxx
+  itkWasmTransformInterfaceBSplineTest.cxx
 )
 
 if (EMSCRIPTEN)
@@ -312,6 +313,11 @@ itk_add_test(NAME itkWasmTransformInterfaceCompositeTest
     itkWasmTransformInterfaceCompositeTest
       DATA{Input/CompositeTransform.h5}
       ${ITK_TEST_OUTPUT_DIR}/itkWasmTransformInterfaceCompositeTest.h5
+)
+
+itk_add_test(NAME itkWasmTransformInterfaceBSplineTest
+    COMMAND WebAssemblyInterfaceTestDriver
+    itkWasmTransformInterfaceBSplineTest
 )
 
 if(EMSCRIPTEN)

--- a/test/itkWasmTransformInterfaceBSplineTest.cxx
+++ b/test/itkWasmTransformInterfaceBSplineTest.cxx
@@ -1,0 +1,104 @@
+/*=========================================================================
+ *
+ *  Copyright NumFOCUS
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+#include "itkTransformToWasmTransformFilter.h"
+#include "itkWasmTransformToTransformFilter.h"
+
+#include "itkAffineTransform.h"
+#include "itkBSplineTransform.h"
+#include "itkCompositeTransform.h"
+#include "itkTestingMacros.h"
+
+// A B-spline round trip through the Wasm transform interface. Unlike the other
+// parameterizations, itk::BSplineTransform does not size the base
+// m_Parameters, so filling it with CopyInParameters overruns a zero-length
+// buffer. The composite mirrors what a rigid -> affine -> bspline registration
+// produces.
+int
+itkWasmTransformInterfaceBSplineTest(int, char *[])
+{
+  constexpr unsigned int Dimension = 2;
+  constexpr unsigned int SplineOrder = 3;
+  using ParametersValueType = double;
+  using BSplineTransformType = itk::BSplineTransform<ParametersValueType, Dimension, SplineOrder>;
+  using AffineTransformType = itk::AffineTransform<ParametersValueType, Dimension>;
+  using TransformType = itk::CompositeTransform<ParametersValueType, Dimension>;
+
+  auto bsplineTransform = BSplineTransformType::New();
+  BSplineTransformType::OriginType meshOrigin;
+  meshOrigin.Fill(0.0);
+  BSplineTransformType::PhysicalDimensionsType meshPhysicalDimensions;
+  meshPhysicalDimensions.Fill(64.0);
+  BSplineTransformType::DirectionType meshDirection;
+  meshDirection.SetIdentity();
+  BSplineTransformType::MeshSizeType meshSize;
+  meshSize.Fill(4);
+  bsplineTransform->SetTransformDomainOrigin(meshOrigin);
+  bsplineTransform->SetTransformDomainPhysicalDimensions(meshPhysicalDimensions);
+  bsplineTransform->SetTransformDomainDirection(meshDirection);
+  bsplineTransform->SetTransformDomainMeshSize(meshSize);
+
+  // Vary the coefficients so a parameter ordering error would change the mapping.
+  BSplineTransformType::ParametersType coefficients(bsplineTransform->GetNumberOfParameters());
+  for (unsigned int i = 0; i < coefficients.Size(); ++i)
+  {
+    coefficients[i] = 0.25 * static_cast<ParametersValueType>(i % 17) - 2.0;
+  }
+  bsplineTransform->SetParametersByValue(coefficients);
+
+  auto affineTransform = AffineTransformType::New();
+  AffineTransformType::OutputVectorType translation;
+  translation[0] = 3.0;
+  translation[1] = -1.5;
+  affineTransform->Translate(translation);
+
+  auto inputTransform = TransformType::New();
+  inputTransform->AddTransform(affineTransform);
+  inputTransform->AddTransform(bsplineTransform);
+
+  using TransformToWasmTransformFilterType = itk::TransformToWasmTransformFilter<TransformType>;
+  auto transformToJSONFilter = TransformToWasmTransformFilterType::New();
+  transformToJSONFilter->SetTransform(inputTransform);
+  ITK_TRY_EXPECT_NO_EXCEPTION(transformToJSONFilter->Update());
+
+  using WasmTransformToTransformFilterType = itk::WasmTransformToTransformFilter<TransformType>;
+  auto jsonToTransformFilter = WasmTransformToTransformFilterType::New();
+  jsonToTransformFilter->SetInput(transformToJSONFilter->GetOutput());
+  ITK_TRY_EXPECT_NO_EXCEPTION(jsonToTransformFilter->Update());
+  TransformType::Pointer convertedTransform = jsonToTransformFilter->GetOutput();
+
+  ITK_TEST_EXPECT_EQUAL(convertedTransform->GetNumberOfTransforms(), inputTransform->GetNumberOfTransforms());
+  ITK_TEST_EXPECT_EQUAL(convertedTransform->GetParameters().Size(), inputTransform->GetParameters().Size());
+
+  // The mapping itself must survive, not just the parameter count.
+  TransformType::InputPointType point;
+  for (const auto & coordinates : { std::array<double, 2>{ 0.0, 0.0 },
+                                    std::array<double, 2>{ 16.0, 48.0 },
+                                    std::array<double, 2>{ 63.0, 63.0 } })
+  {
+    point[0] = coordinates[0];
+    point[1] = coordinates[1];
+    const auto expected = inputTransform->TransformPoint(point);
+    const auto actual = convertedTransform->TransformPoint(point);
+    for (unsigned int d = 0; d < Dimension; ++d)
+    {
+      ITK_TEST_EXPECT_TRUE(itk::Math::FloatAlmostEqual(expected[d], actual[d]));
+    }
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
CopyInFixedParameters/CopyInParameters std::copy into the transform's existing m_FixedParameters/m_Parameters without resizing them; the base class documents the requirement as "the range of values must conform to std::copy(begin, end, m_Parameters)". That holds for transforms that size those members in their constructor, but not for itk::BSplineTransform: its parameter count is unknown until the grid is set, and it keeps its coefficients in its own m_InternalParametersBuffer, so the base m_Parameters stays empty. Copying into it runs off the end of a zero-length buffer, which segfaults natively and aborts the module with no diagnostic under WebAssembly.

Use SetFixedParameters and SetParametersByValue instead, which every transform implements as a copy, and check the parameter count so a mismatch reports instead of corrupting memory. Fixed parameters are set first: for a B-spline they define the grid, and hence the number of parameters.

Fixed in both places that reconstruct a transform from TransformListJSON: itkWasmTransformToTransformFilter, in its composite and non-composite branches, and the copy of that pattern in the downsample package's resample pipelines.

Adds itkWasmTransformInterfaceBSplineTest, which round-trips a composite containing a B-spline through the interface. No existing test exercised a B-spline on this path, which is why the defect went unnoticed; the new test segfaults without this change.

Closes #1580