### PR TITLE
fix(itkwasm): support wasmtime 48

### DIFF
--- a/packages/core/python/itkwasm/itkwasm/pipeline.py
+++ b/packages/core/python/itkwasm/itkwasm/pipeline.py
@@ -46,8 +46,6 @@ if sys.platform != "emscripten":
         WasiConfig,
         Linker,
         WasmtimeError,
-        DirPerms,
-        FilePerms
     )
 
     # Get the value of the ITKWASM_CACHE_DIR environment variable
@@ -86,7 +84,12 @@ class RunInstance:
         wasi_config.argv = args
 
         for preopen in preopen_directories:
-            wasi_config.preopen_dir(preopen, preopen, DirPerms.READ_WRITE, FilePerms.READ_WRITE)
+            # Read-write is the default on both sides of the wasmtime 48.0.0
+            # signature change: `dir_perms=DirPerms.READ_WRITE,
+            # file_perms=FilePerms.READ_WRITE` up to 47.0.1, `fs_mutable=True`
+            # from 48.0.0, where the two enums were removed. Passing neither
+            # keeps read-write across the supported range.
+            wasi_config.preopen_dir(preopen, preopen)
 
         store.set_wasi(wasi_config)
 


### PR DESCRIPTION
`import itkwasm` fails on wasmtime >= 48.0.0, released 2026-08-20:

```
ImportError: cannot import name 'DirPerms' from 'wasmtime'
```

`pipeline.py` imports `DirPerms` and `FilePerms` at module scope, so the failure hits at import time, before anything runs. Any test suite that imports itkwasm from a `conftest.py` dies during collection.

## What changed upstream

wasmtime 48.0.0 simplified wasi-filesystem permissions to read-write or read-only per directory ([bytecodealliance/wasmtime#14010](https://github.com/bytecodealliance/wasmtime/pull/14010), listed under *Changed* in the [48.0.0 notes](https://github.com/bytecodealliance/wasmtime/releases/tag/v48.0.0)). In the Python bindings ([bytecodealliance/wasmtime-py@2ed8d10](https://github.com/bytecodealliance/wasmtime-py/commit/2ed8d100)) both enums are deleted and the signature becomes:

```python
# 28.0.0 through 47.0.1
def preopen_dir(self, path, guest_path,
                dir_perms=DirPerms.READ_WRITE, file_perms=FilePerms.READ_WRITE)
# 48.0.0
def preopen_dir(self, path, guest_path, fs_mutable: bool = True)
```

## The fix

Read-write is the default on **both** sides of that change, so passing neither permission argument keeps the current behaviour across the whole declared `wasmtime >= 28.0.0` range. No version branching, no `try`/`except`, no floor bump.

Signature checked at every relevant tag:

| wasmtime | `preopen_dir` signature |
| --- | --- |
| 28.0.0 | `dir_perms=DirPerms.READ_WRITE, file_perms=FilePerms.READ_WRITE` |
| 33.0.0 | same |
| 40.0.0 | same |
| 47.0.1 | same |
| 48.0.0 | `fs_mutable: bool = True` |

## Verification

`Pipeline.run` builds `preopen_directories` from `TextFile` and `BinaryFile` interfaces only, so a pipeline carrying images or streams leaves the list empty and never enters the changed loop. Verification therefore drives the same wasm module and inputs as `test/test_pipeline.py::test_pipeline_input_output_files`: `input-output-files-test.wasi.wasm` with a text and a binary input read from one preopened directory, and both outputs written into a second, asserting the bytes that land on disk.

| wasmtime | preopened directories | result |
| --- | --- | --- |
| 28.0.0 (declared floor) | 2 (input, output) | guest read and wrote, bytes match |
| 47.0.1 (last with the enums) | 2 | guest read and wrote, bytes match |
| 48.0.0 (removes them) | 2 | guest read and wrote, bytes match |

`RunInstance.__init__` was instrumented for those runs to confirm the two directories reach `preopen_dir` rather than assuming it.

`DirPerms` and `FilePerms` appear nowhere else in the repository.

## One coverage note, outside this fix

No CI job exercises `test_pipeline_input_output_files`: the `python-wasm.yml` matrix covers the derived packages (`downsample`, `image-io`, ...), not `packages/core/python/itkwasm`, and those packages' pixi environments resolve `itkwasm` from released PyPI wheels rather than from the local tree. Every `pixi.lock` in the repository also pins wasmtime below 48. So this change, and the `preopen_dir` call in general, is not covered by the current matrix on any wasmtime version.
