### PR TITLE
fix(itkwasm): support the wasmtime-py 48 preopen_dir signature

### DIFF
--- a/packages/core/python/itkwasm/itkwasm/__init__.py
+++ b/packages/core/python/itkwasm/itkwasm/__init__.py
@@ -1,6 +1,6 @@
 """itkwasm: Python interface to itk-wasm WebAssembly modules."""
 
-__version__ = "1.0b200"
+__version__ = "1.0b201"
 
 from .interface_types import InterfaceTypes
 from .image import Image, ImageType, ImageRegion

--- a/packages/core/python/itkwasm/itkwasm/pipeline.py
+++ b/packages/core/python/itkwasm/itkwasm/pipeline.py
@@ -46,8 +46,6 @@ if sys.platform != "emscripten":
         WasiConfig,
         Linker,
         WasmtimeError,
-        DirPerms,
-        FilePerms
     )
 
     # Get the value of the ITKWASM_CACHE_DIR environment variable
@@ -86,7 +84,10 @@ class RunInstance:
         wasi_config.argv = args
 
         for preopen in preopen_directories:
-            wasi_config.preopen_dir(preopen, preopen, DirPerms.READ_WRITE, FilePerms.READ_WRITE)
+            # Read-write access is the default in every supported wasmtime; passing
+            # it explicitly is not portable -- wasmtime 48 replaced the DirPerms /
+            # FilePerms arguments with a single fs_mutable flag.
+            wasi_config.preopen_dir(preopen, preopen)
 
         store.set_wasi(wasi_config)
 

--- a/packages/core/python/itkwasm/test/test_pipeline.py
+++ b/packages/core/python/itkwasm/test/test_pipeline.py
@@ -1,4 +1,5 @@
 from pathlib import Path, PurePosixPath
+import shutil
 import tempfile
 from dataclasses import asdict
 import sys
@@ -130,6 +131,66 @@ def test_pipeline_input_output_files():
             content = fp.read()
             assert content == "The answer is 42."
         assert outputs[1].type, InterfaceTypes.BinaryFile
+        with open(outputs[1].data.path, "rb") as fp:
+            content = fp.read()
+            assert content[0] == 222
+            assert content[1] == 173
+            assert content[2] == 190
+            assert content[3] == 239
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows tempfile resource, https://github.com/bytecodealliance/wasmtime-py/issues/132",
+)
+def test_pipeline_input_output_files_same_directory():
+    """A directory preopened for both input and output is read-write.
+
+    Inputs and outputs in the same directory collapse to a single preopen, so
+    that one preopen must serve reads and writes. This pins the read-write
+    default relied on by RunInstance.preopen_dir.
+    """
+    pipeline = Pipeline(test_input_dir / "input-output-files-test.wasi.wasm")
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        tmpdir = Path(tmpdirname)
+        shutil.copy(test_input_dir / "input.txt", tmpdir / "input.txt")
+        shutil.copy(test_input_dir / "input.bin", tmpdir / "input.bin")
+
+        input_text_file = PurePosixPath(tmpdir / "input.txt")
+        input_binary_file = PurePosixPath(tmpdir / "input.bin")
+        output_text_file = PurePosixPath(tmpdir / "output.txt")
+        output_binary_file = PurePosixPath(tmpdir / "output.bin")
+
+        pipeline_inputs = [
+            PipelineInput(InterfaceTypes.TextFile, TextFile(input_text_file)),
+            PipelineInput(InterfaceTypes.BinaryFile, BinaryFile(input_binary_file)),
+        ]
+
+        pipeline_outputs = [
+            PipelineOutput(InterfaceTypes.TextFile, TextFile(output_text_file)),
+            PipelineOutput(InterfaceTypes.BinaryFile, BinaryFile(output_binary_file)),
+        ]
+
+        args = [
+            "--memory-io",
+            "--use-files",
+            "--input-text-file",
+            str(input_text_file),
+            "--input-binary-file",
+            str(input_binary_file),
+            "--output-text-file",
+            str(output_text_file),
+            "--output-binary-file",
+            str(output_binary_file),
+        ]
+
+        outputs = pipeline.run(args, pipeline_outputs, pipeline_inputs)
+
+        assert outputs[0].type == InterfaceTypes.TextFile
+        with open(outputs[0].data.path, "r") as fp:
+            assert fp.read() == "The answer is 42."
+        assert outputs[1].type == InterfaceTypes.BinaryFile
         with open(outputs[1].data.path, "rb") as fp:
             content = fp.read()
             assert content[0] == 222


### PR DESCRIPTION
## Problem

`wasmtime-py` 48.0.0 removed the `DirPerms` and `FilePerms` enums and changed the
`WasiConfig.preopen_dir` signature:

| wasmtime-py | signature | exports `DirPerms` / `FilePerms` |
| --- | --- | --- |
| 28.0.0 – 47.x | `preopen_dir(path, guest_path, dir_perms=DirPerms.READ_WRITE, file_perms=FilePerms.READ_WRITE)` | yes |
| 48.0.0 | `preopen_dir(path, guest_path, fs_mutable=True)` | **no** |

`itkwasm/pipeline.py` imported both names at module scope, inside the
`if sys.platform != "emscripten":` block. So on wasmtime-py 48 the failure was not
limited to pipelines that perform file I/O — plain `import itkwasm` raised
`ImportError`, breaking the package for every user who picked up the new wasmtime.

## Changes

Drop the two imports and pass only the path arguments:

```python
for preopen in preopen_directories:
    wasi_config.preopen_dir(preopen, preopen)
```

Read-write is the **default on both sides of the break** — `DirPerms.READ_WRITE` /
`FilePerms.READ_WRITE` on ≤ 47, `fs_mutable=True` on 48 — so the two-argument call is
semantically identical across the whole supported range. That means no conditional
import, no `try`/`except ImportError` shim, and no version-sniffing branch; it also
keeps the existing `wasmtime >= 28.0.0` floor in `pyproject.toml` valid, so no
dependency bound needed changing.

Every other wasmtime API this module touches was checked against 48.0.0 and is
unchanged: the nine `Config` feature flags (`wasm_bulk_memory`, `wasm_simd`,
`wasm_relaxed_simd`, `wasm_relaxed_simd_deterministic`, `wasm_memory64`,
`cranelift_opt_level`, `strategy`, `cache`, `parallel_compilation`),
`WasiConfig.inherit_*` / `argv`, `Module.deserialize_file`, and `Linker.define_wasi`.
`DirPerms` / `FilePerms` were the only casualties.

## Test coverage

The changed lines were already executed by the existing suite, but line coverage was
misleading here. In `test_pipeline_input_output_files` the inputs live in
`test/input/` and the outputs in a temporary directory, so the run produces **two**
preopens, each exercised read-only *or* write-only. The case where a **single**
preopen must serve both reads and writes — precisely the read-write default this fix
now leans on — had no coverage.

`test_pipeline_input_output_files_same_directory` closes that gap: it copies both
inputs into the temp directory so `preopen_directories` collapses to one entry that
has to handle reads and writes at once. It carries the same win32 `skipif` as its
sibling test.

To confirm the new test is not vacuous, the preopen was temporarily mutated to
read-only (`preopen_dir(preopen, preopen, False)`); both file tests then fail with
`Could not open outputTxtFile.`, so the test genuinely pins the semantics rather than
passing by construction.

## Verification

`packages/core/python/itkwasm/test/test_pipeline.py` was run against both ends of the
supported range, in isolated environments:

- **wasmtime-py 28.0.0** (dependency floor) — `import itkwasm` OK, 11 passed
- **wasmtime-py 48.0.0** (the breaking release) — `import itkwasm` OK, 11 passed

`test_pipeline_dask_array_input` was deselected in both local runs because `dask` is
absent from the minimal verification venvs; it is unrelated to this change and CI
runs it via the full pixi environment.

CodeRabbit review on the diff returned 0 findings.

## Notes for reviewers

- This branch also contains a separate `chore` commit bumping `__version__`
  from `1.0b200` to `1.0b201`, so the fix can ship to PyPI.
- No documentation updates were needed: neither `AGENTS.md`, the root `README.md`,
  nor `packages/core/python/itkwasm/README.md` documents wasmtime version
  constraints, and this change alters no public API, environment variable, or
  developer workflow.
- `black --check` reports `pipeline.py` as unformatted, but it does so on the
  unmodified file at `main` as well (pre-existing trailing whitespace elsewhere in
  the file), and the `black` diff does not touch the changed region. Left alone here
  to keep this fix's diff small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
