### PR TITLE
fix(itk-wasm): spell TimeVaryingVelocityField parameterizations with the y

### DIFF
--- a/packages/core/typescript/itk-wasm/src/interface-types/transform-parameterizations.ts
+++ b/packages/core/typescript/itk-wasm/src/interface-types/transform-parameterizations.ts
@@ -27,9 +27,9 @@ const TransformParameterizations = {
     'GaussianSmoothingOnUpdateDisplacementField',
   GaussianExponentialDiffeomorphic: 'GaussianExponentialDiffeomorphic',
   VelocityField: 'VelocityField',
-  TimeVaringVelocityField: 'TimeVaringVelocityField',
-  GaussianSmoothingOnUpdateTimeVaringVelocityField:
-    'GaussianSmoothingOnUpdateTimeVaringVelocityField'
+  TimeVaryingVelocityField: 'TimeVaryingVelocityField',
+  GaussianSmoothingOnUpdateTimeVaryingVelocityField:
+    'GaussianSmoothingOnUpdateTimeVaryingVelocityField'
 } as const
 
 export default TransformParameterizations

--- a/packages/core/typescript/itk-wasm/test/node/interface-types/transform-parameterizations-test.js
+++ b/packages/core/typescript/itk-wasm/test/node/interface-types/transform-parameterizations-test.js
@@ -1,0 +1,20 @@
+import test from 'ava'
+
+import { TransformParameterizations } from '../../../dist/index-node.js'
+
+test('every parameterization value is its own key', (t) => {
+  for (const [key, value] of Object.entries(TransformParameterizations)) {
+    t.is(value, key)
+  }
+})
+
+test('time-varying velocity field parameterizations match the ITK class names', (t) => {
+  t.is(TransformParameterizations.TimeVaryingVelocityField, 'TimeVaryingVelocityField')
+  t.is(
+    TransformParameterizations.GaussianSmoothingOnUpdateTimeVaryingVelocityField,
+    'GaussianSmoothingOnUpdateTimeVaryingVelocityField'
+  )
+  for (const key of Object.keys(TransformParameterizations)) {
+    t.false(key.includes('Varing'))
+  }
+})


### PR DESCRIPTION
The `TransformParameterizations` table in `packages/core/typescript/itk-wasm/src/interface-types/transform-parameterizations.ts` spelled two entries `TimeVaringVelocityField` and `GaussianSmoothingOnUpdateTimeVaringVelocityField`, both as key and as value. Everywhere else the name carries the y: `JSONTransformParameterizationEnum` in `include/itkTransformJSON.h`, the C++ class names the serializer matches on (`TimeVaryingVelocityFieldTransform`, `GaussianSmoothingOnUpdateTimeVaryingVelocityFieldTransform`), and the Python `itkwasm.TransformParameterizations` enum. A TypeScript consumer comparing `transformParameterization` against any of those never matched these two entries.

This corrects the four spellings and adds `test/node/interface-types/transform-parameterizations-test.js`, which checks that every value is its own key and that the two time-varying entries match the ITK class names.

The C++ side never emitted the misspelled strings (it writes from the enum in `itkTransformJSON.h`), so no reader needs to accept the old spelling. The two keys change name in the TypeScript API for callers that referenced `TransformParameterizations.TimeVaringVelocityField` directly.

Verified locally: `tsc` build, `ava` on the new test and `transform-type-test.js` (6 passed), `standard` and `ts-standard` clean.

Closes #1591